### PR TITLE
[fix] 修复"新增按键映射"按钮允许等待输入时重复点击的BUG

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -518,11 +518,22 @@ void MainWindow::on_pushButton_clicked()
         return;
     }
 
+    // 禁用按钮，防止重复点击
+    ui->pushButton->setEnabled(false); 
+    ui->pushButton->setText("等待输入...");
+
+    // 下面的函数会导致界面卡死, 需要重绘一下
+    this->repaint ();
+
     paintOneLineMapping(nullptr, -1);
 
     QTimer::singleShot(50, [=](){
         QScrollBar *sbar = ui->scrollArea->verticalScrollBar();
         sbar->setValue(sbar->maximum());
+
+        // 恢复按钮状态
+        ui->pushButton->setText("新增按键映射");
+        ui->pushButton->setEnabled(true);
     });
 }
 


### PR DESCRIPTION
Hello啊，本分支修复了"新增按键映射"按钮允许等待输入时重复点击的BUG，请见截图&提交的代码。已完成自验。

- 修复前，重复点击该按钮会较长时间卡住：
![445ea465a80b089a992cb280be982bf4](https://github.com/user-attachments/assets/f3236242-db4e-4ae3-9c81-b2bc663cf064)


- 修复后，点击一次会禁用按键（检测结束后随定时器恢复按键）：
![image](https://github.com/user-attachments/assets/f17b6705-cadf-43d6-9701-4d550a77d67d)


