### PR TITLE
添加多按键映射功能，方便DIY转向灯玩家等

### DIFF
--- a/global.cpp
+++ b/global.cpp
@@ -285,11 +285,14 @@ QList<MappingRelation*> getInputState(bool enableLog) {
 
 
         // 遍历按键，查看按键是否按下
-        for (int i = 0; i < 128; i++) {
+        std::string btnStr = "";
+        BUTTONS_VALUE_TYPE btnValue = 0;
+        for (int i = 0; i < MAX_BUTTONS; i++) {
             if (js.rgbButtons[i] & 0x80) {
                 //qDebug() << "按键" << i << "被按下";
-                std::string btnStr = "按键" + std::to_string(i);
-                list.append(new MappingRelation(btnStr, WHEEL_BUTTON, i, 0, ""));
+                btnStr += "按键" + std::to_string(i) + "+";
+                btnValue |= 1 << i; // 设置对应的位为1
+                // qDebug("%d, 按键被按下:%s, 值:%X", i, btnStr.data(), btnValue);
             }
 
             // 记录日志
@@ -302,6 +305,12 @@ QList<MappingRelation*> getInputState(bool enableLog) {
                 }
 
             }
+        }
+        if (!btnStr.empty()) {
+            // 映射按键
+            btnStr = btnStr.substr(0, btnStr.length() - 1);// 去掉最后的 "+"
+            list.append(new MappingRelation(btnStr, WHEEL_BUTTON, btnValue, 0, ""));
+            // qDebug("按键被按下:%s, 值:%X", btnStr.data(), btnValue);
         }
         if(enableLog && getEnableBtnLog()){
             btnLog.append("}");

--- a/global.h
+++ b/global.h
@@ -69,7 +69,7 @@ double getInnerDeadAreaTaban();
 BOOL CALLBACK EnumDevicesCallback(const DIDEVICEINSTANCE* pdidInstance, VOID* pContext);
 bool initDirectInput();
 bool openDiDevice(int deviceIndex);
-QList<MappingRelation*> getInputState(bool enableLog);
+QList<MappingRelation*> getInputState(bool enableLog, std::vector<MappingRelation> multiBtnVector = {});
 void cleanupDirectInput();
 void getDipropRange(long axisCode, std::string axisName);
 // 扫描设备

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -373,7 +373,6 @@ void MainWindow::paintOneLineMapping(MappingRelation *mapping, int index){
 
         int col = -1;
         layout->addWidget(h1, 0, ++col, Qt::AlignLeft);
-        // layout->addWidget(h2, 0, ++col, Qt::AlignLeft);
         layout->addWidget(h3, 0, ++col, Qt::AlignLeft);
         layout->addWidget(h4, 0, ++col, Qt::AlignLeft);
         layout->addWidget(h5, 0, ++col, Qt::AlignLeft);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -201,13 +201,6 @@ void MainWindow::on_pushButton_2_clicked()
         }
 
         // 创建监听设备输入数据的任务
-        // 对mappingList进行对 dev_btn_name长度的排序, 使得映射按键的名称从长到短排列
-        std::sort(mappingList.begin(), mappingList.end(), [](MappingRelation* a, MappingRelation* b) {
-            if (!a || !b) {
-                return false;  // 将空指针排在末尾
-            }
-            return a->dev_btn_name > b->dev_btn_name;
-        });
         SimulateTask *task = new SimulateTask(&mappingList);
         QThread *thread = new QThread();
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -201,6 +201,13 @@ void MainWindow::on_pushButton_2_clicked()
         }
 
         // 创建监听设备输入数据的任务
+        // 对mappingList进行对 dev_btn_name长度的排序, 使得映射按键的名称从长到短排列
+        std::sort(mappingList.begin(), mappingList.end(), [](MappingRelation* a, MappingRelation* b) {
+            if (!a || !b) {
+                return false;  // 将空指针排在末尾
+            }
+            return a->dev_btn_name > b->dev_btn_name;
+        });
         SimulateTask *task = new SimulateTask(&mappingList);
         QThread *thread = new QThread();
 
@@ -560,7 +567,8 @@ void MainWindow::saveMappingsToFile(std::string filename){
                         + std::to_string(item->keyboard_value) + SPE
                         + item->remark + SPE
                         + std::to_string(item->rotateAxis) + SPE
-                        + std::to_string(item->btnTriggerType)
+                        + std::to_string(item->btnTriggerType) + SPE
+                        + MappingRelation::buttonsValueTypeToStr(item->dev_btn_value)
                         + "\n");
         }
     }
@@ -735,6 +743,9 @@ void MainWindow::loadMappingsFile(std::string filename){
                     mapping->btnTriggerType = static_cast<TriggerTypeEnum>(list[6].toInt());
                 }else{
                     mapping->btnTriggerType = TriggerTypeEnum::Normal;
+                }
+                if (list.size() >= 8 && list[7] != nullptr && !list[7].isEmpty()) {
+                    mapping->dev_btn_value = MappingRelation::strToButtonsValueType(list[7].toStdString());
                 }
                 mappingList.push_back(mapping);
             }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -362,10 +362,7 @@ void MainWindow::paintOneLineMapping(MappingRelation *mapping, int index){
         QLabel *h1 = new QLabel("设备按键");
         h1->setStyleSheet("font-weight: bold;"); // 设置样式表实现加粗
 
-        QLabel *h2 = new QLabel("映射成");
-        h2->setStyleSheet("font-weight: bold;"); // 设置样式表实现加粗
-
-        QLabel *h3 = new QLabel(getIsXboxMode() ? "Xbox按键" : "键盘按键");
+        QLabel *h3 = new QLabel(getIsXboxMode() ? "映射成 -> Xbox按键" : "映射成 -> 键盘按键");
         h3->setStyleSheet("font-weight: bold;"); // 设置样式表实现加粗
 
         QLabel *h4 = new QLabel("按键触发模式");
@@ -376,7 +373,7 @@ void MainWindow::paintOneLineMapping(MappingRelation *mapping, int index){
 
         int col = -1;
         layout->addWidget(h1, 0, ++col, Qt::AlignLeft);
-        layout->addWidget(h2, 0, ++col, Qt::AlignLeft);
+        // layout->addWidget(h2, 0, ++col, Qt::AlignLeft);
         layout->addWidget(h3, 0, ++col, Qt::AlignLeft);
         layout->addWidget(h4, 0, ++col, Qt::AlignLeft);
         layout->addWidget(h5, 0, ++col, Qt::AlignLeft);
@@ -388,16 +385,9 @@ void MainWindow::paintOneLineMapping(MappingRelation *mapping, int index){
             : mapping->dev_btn_name.data());
     label1->setMaximumHeight(30);
     label1->setMinimumHeight(30);
-    label1->setMaximumWidth(90);
+    label1->setMaximumWidth(150);
     label1->setStyleSheet("QLabel{color:blue;}");
     label1->setObjectName(currentRowIndex);
-
-    QLabel *label2 = new QLabel("->");
-    label2->setMaximumHeight(30);
-    label2->setMinimumHeight(30);
-    label2->setMaximumWidth(60);
-    label2->setObjectName(currentRowIndex);
-
 
     // 键盘按键下拉框
     QComboBox *comboBox = createAKeyBoardComboBox(
@@ -463,7 +453,6 @@ void MainWindow::paintOneLineMapping(MappingRelation *mapping, int index){
     int columnIndex = -1;
     int row = (index < 0 ? mappingList.size() : index) + 1;
     layout->addWidget(label1, row, ++columnIndex, Qt::AlignLeft);
-    layout->addWidget(label2, row, ++columnIndex, Qt::AlignLeft);
     layout->addWidget(comboBox, row, ++columnIndex, Qt::AlignLeft);
     layout->addWidget(triggerTypeComboBox, row, ++columnIndex, Qt::AlignLeft); // triggerTypeComboBox
     layout->addWidget(lineEdit, row, ++columnIndex, Qt::AlignLeft);

--- a/mapping_relation.h
+++ b/mapping_relation.h
@@ -4,8 +4,8 @@
 #include<string>
 
 //using namespace std;
-#define BUTTONS_VALUE_TYPE int64_t
-#define MAX_BUTTONS (sizeof(BUTTONS_VALUE_TYPE) * 8) // 64位整数, 最大按键数为64个
+#define BUTTONS_VALUE_TYPE int32_t
+#define MAX_BUTTONS (sizeof(BUTTONS_VALUE_TYPE) * 8)
 
 class MappingRelation{
 public:
@@ -52,20 +52,30 @@ public:
     }
 
     static BUTTONS_VALUE_TYPE strToButtonsValueType(const std::string& str) {
-        BUTTONS_VALUE_TYPE result = 0;
-        for (char c : str) {
-            result = result * 10 + (c - '0');
-        }
-        return result;
+        // BUTTONS_VALUE_TYPE result = 0;
+        // for (char c : str) {
+        //     result = result * 10 + (c - '0');
+        // }
+        // return result;
+        return std::stoi(str);
     }
 
     static std::string buttonsValueTypeToStr(BUTTONS_VALUE_TYPE value) {
-        std::string result;
-        while (value > 0) {
-            result = static_cast<char>('0' + (value % 10)) + result;
-            value /= 10;
+        // std::string result;
+        // while (value > 0) {
+        //     result = static_cast<char>('0' + (value % 10)) + result;
+        //     value /= 10;
+        // }
+        // return result.empty() ? "0" : result;
+        return std::to_string(value);
+    }
+
+    static std::string toBitStr(BUTTONS_VALUE_TYPE value) {
+        std::string bitStr;
+        for (int i = 0; i < sizeof(BUTTONS_VALUE_TYPE) * 8; ++i) {
+            bitStr += (value & (1 << i)) ? '1' : '0';
         }
-        return result.empty() ? "0" : result;
+        return bitStr;
     }
 };
 

--- a/mapping_relation.h
+++ b/mapping_relation.h
@@ -4,13 +4,15 @@
 #include<string>
 
 //using namespace std;
+#define BUTTONS_VALUE_TYPE int64_t
+#define MAX_BUTTONS (sizeof(BUTTONS_VALUE_TYPE) * 8) // 64位整数, 最大按键数为64个
 
 class MappingRelation{
 public:
     int dev_btn_pos; // 设备按键位置
     std::string dev_btn_name;// 设备按键名称
     std::string dev_btn_type;// 设备按键类型(用于区分方向盘的轴和按键)
-    int dev_btn_value; // 设备按键值
+    BUTTONS_VALUE_TYPE dev_btn_value; // 设备按键值
     short keyboard_value;// 键盘按键值
     std::string keyboard_name;// 键盘按键名称
     std::string remark; // 备注
@@ -18,21 +20,21 @@ public:
     TriggerTypeEnum btnTriggerType; // 按键触发类型
 
     MappingRelation(){}
-    MappingRelation(int dev_btn_pos, int dev_btn_value, short keyboard_value, std::string keyboard_name){
+    MappingRelation(int dev_btn_pos, BUTTONS_VALUE_TYPE dev_btn_value, short keyboard_value, std::string keyboard_name){
         this->dev_btn_pos = dev_btn_pos;
         this->dev_btn_value = dev_btn_value;
         this->keyboard_value = keyboard_value;
         this->keyboard_name = keyboard_name;
     }
 
-    MappingRelation(std::string dev_btn_name, int dev_btn_value, short keyboard_value, std::string keyboard_name){
+    MappingRelation(std::string dev_btn_name, BUTTONS_VALUE_TYPE dev_btn_value, short keyboard_value, std::string keyboard_name){
         this->dev_btn_name = dev_btn_name;
         this->dev_btn_value = dev_btn_value;
         this->keyboard_value = keyboard_value;
         this->keyboard_name = keyboard_name;
     }
 
-    MappingRelation(std::string dev_btn_name, std::string dev_btn_type,int dev_btn_value, short keyboard_value, std::string keyboard_name){
+    MappingRelation(std::string dev_btn_name, std::string dev_btn_type,BUTTONS_VALUE_TYPE dev_btn_value, short keyboard_value, std::string keyboard_name){
         this->dev_btn_name = dev_btn_name;
         this->dev_btn_type = dev_btn_type;
         this->dev_btn_value = dev_btn_value;
@@ -40,13 +42,30 @@ public:
         this->keyboard_name = keyboard_name;
     }
 
-    MappingRelation(std::string dev_btn_name, std::string dev_btn_type,int dev_btn_value, short keyboard_value, std::string keyboard_name, TriggerTypeEnum btnTriggerType){
+    MappingRelation(std::string dev_btn_name, std::string dev_btn_type,BUTTONS_VALUE_TYPE dev_btn_value, short keyboard_value, std::string keyboard_name, TriggerTypeEnum btnTriggerType){
         this->dev_btn_name = dev_btn_name;
         this->dev_btn_type = dev_btn_type;
         this->dev_btn_value = dev_btn_value;
         this->keyboard_value = keyboard_value;
         this->keyboard_name = keyboard_name;
         this->btnTriggerType = btnTriggerType;
+    }
+
+    static BUTTONS_VALUE_TYPE strToButtonsValueType(const std::string& str) {
+        BUTTONS_VALUE_TYPE result = 0;
+        for (char c : str) {
+            result = result * 10 + (c - '0');
+        }
+        return result;
+    }
+
+    static std::string buttonsValueTypeToStr(BUTTONS_VALUE_TYPE value) {
+        std::string result;
+        while (value > 0) {
+            result = static_cast<char>('0' + (value % 10)) + result;
+            value /= 10;
+        }
+        return result.empty() ? "0" : result;
     }
 };
 

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -44,23 +44,24 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
     this->mappingList = mappingList;
 
     for(MappingRelation* mapping : *mappingList){
+        // 兼容性处理, 如果没有设置按键值, 则根据按键名称设置按键值
+        if (mapping->dev_btn_value == 0) {
+            std::string btnStr = mapping->dev_btn_name;
+            if (btnStr.find("按键") != std::string::npos && btnStr.find("+") == std::string::npos) {
+                int index = QString(btnStr.data()).right(1).toInt();
+                mapping->dev_btn_value = 1 << index; // 设置按键值
+                qDebug("%s 按键值为0, 索引: %d, 设置为:0x%X", btnStr.data(), index, mapping->dev_btn_value);
+            }
+        }
+
         if(isMappingValid(mapping)){
             addMappingToHandleMap(mapping);
         }
-        MappingRelation newMapping = *mapping;
         if (mapping->dev_btn_value > 0) {
+            MappingRelation newMapping = *mapping;
             handleMultiBtnVector.push_back(newMapping);
-            qDebug("添加按键映射到handleMultiBtnVector: %s, 0x%X,  %d", mapping->dev_btn_name.data(), mapping->dev_btn_value, mapping->keyboard_value);
-        } else if (mapping->dev_btn_value == 0) {
-            // 兼容性处理, 如果没有设置按键值, 则跳过
-            std::string btnStr = mapping->dev_btn_name;
-            if (newMapping.dev_btn_value == 0 && btnStr.find("按键") != std::string::npos && btnStr.find("+") == std::string::npos) {
-                int index = QString(btnStr.data()).right(1).toInt();
-                qDebug("按键值为0, 需要设置按键值, 按键名称: %s, 按键索引: %d", btnStr.data(), index);
-                newMapping.dev_btn_value = 1 << index; // 设置按键值
-                handleMultiBtnVector.push_back(newMapping);
-            }
-        }
+            // qDebug("添加按键映射到handleMultiBtnVector: %s, 0x%X,  %d", mapping->dev_btn_name.data(), mapping->dev_btn_value, mapping->keyboard_value);
+        }  
     }
 }
 

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -63,6 +63,25 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
             // qDebug("添加按键映射到handleMultiBtnVector: %s, 0x%X,  %d", mapping->dev_btn_name.data(), mapping->dev_btn_value, mapping->keyboard_value);
         }  
     }
+
+    // 对handleMultiBtnVector进行对 dev_btn_name长度的排序, 使得映射按键的名称从长到短排列
+    std::sort(handleMultiBtnVector.begin(), handleMultiBtnVector.end(), [](MappingRelation a, MappingRelation b) {
+        if (a.dev_btn_value == 0 || b.dev_btn_value == 0) {
+            return false;  // 将空的排在末尾
+        }
+        // 比较加号的数量
+        int aPlusCount = std::count(a.dev_btn_name.begin(), a.dev_btn_name.end(), '+');
+        int bPlusCount = std::count(b.dev_btn_name.begin(), b.dev_btn_name.end(), '+');
+        if (aPlusCount != bPlusCount) {
+            return aPlusCount > bPlusCount;  // 按加号数量降序排列
+        }
+        // 如果加号数量相同, 则字符串大小比较
+        return a.dev_btn_name > b.dev_btn_name;
+    });
+    // 打印排序后的结果
+    for (auto item : handleMultiBtnVector) {
+        qDebug("排序后的按键名称: %s", item.dev_btn_name.data());
+    }
 }
 
 void SimulateTask::closeDevice(){

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -47,10 +47,19 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
         if(isMappingValid(mapping)){
             addMappingToHandleMap(mapping);
         }
+        MappingRelation newMapping = *mapping;
         if (mapping->dev_btn_value > 0) {
-            MappingRelation newMapping = *mapping;
             handleMultiBtnVector.push_back(newMapping);
             qDebug("添加按键映射到handleMultiBtnVector: %s, 0x%X,  %d", mapping->dev_btn_name.data(), mapping->dev_btn_value, mapping->keyboard_value);
+        } else if (mapping->dev_btn_value == 0) {
+            // 兼容性处理, 如果没有设置按键值, 则跳过
+            std::string btnStr = mapping->dev_btn_name;
+            if (newMapping.dev_btn_value == 0 && btnStr.find("按键") != std::string::npos && btnStr.find("+") == std::string::npos) {
+                int index = QString(btnStr.data()).right(1).toInt();
+                qDebug("按键值为0, 需要设置按键值, 按键名称: %s, 按键索引: %d", btnStr.data(), index);
+                newMapping.dev_btn_value = 1 << index; // 设置按键值
+                handleMultiBtnVector.push_back(newMapping);
+            }
         }
     }
 }

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -124,7 +124,7 @@ void SimulateTask::releaseAllKey(QList<MappingRelation*> pressBtnList){
                     // 模拟按下
                     simulateKeyPress(it->second, false);
                     QMetaObject::invokeMethod(QCoreApplication::instance(), [=](){
-                            //释放按键
+                        //释放按键
                         QTimer::singleShot(RELEASE_DELAY_MS, [=](){
                             simulateKeyPress(it->second, true);
                         });
@@ -133,7 +133,7 @@ void SimulateTask::releaseAllKey(QList<MappingRelation*> pressBtnList){
                 default:{
                     // 释放该位置的按键
                     simulateKeyPress(it->second, true);
-                }
+                    }
                 }
 
             }else{
@@ -146,7 +146,7 @@ void SimulateTask::releaseAllKey(QList<MappingRelation*> pressBtnList){
                     // 模拟按下
                     simulateXboxKeyPress(NormalButton, it->second, 0, false);
                     QMetaObject::invokeMethod(QCoreApplication::instance(), [=](){
-                            //释放按键
+                        //释放按键
                         QTimer::singleShot(RELEASE_DELAY_MS, [=](){
                             simulateXboxKeyPress(NormalButton, it->second, 0, true);
                         });

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -47,6 +47,11 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
         if(isMappingValid(mapping)){
             addMappingToHandleMap(mapping);
         }
+        if (mapping->dev_btn_value > 0) {
+            MappingRelation newMapping = *mapping;
+            handleMultiBtnVector.push_back(newMapping);
+            qDebug("添加按键映射到handleMultiBtnVector: %s, 0x%X,  %d", mapping->dev_btn_name.data(), mapping->dev_btn_value, mapping->keyboard_value);
+        }
     }
 }
 
@@ -119,7 +124,7 @@ void SimulateTask::releaseAllKey(QList<MappingRelation*> pressBtnList){
                     // 模拟按下
                     simulateKeyPress(it->second, false);
                     QMetaObject::invokeMethod(QCoreApplication::instance(), [=](){
-                        //释放按键
+                            //释放按键
                         QTimer::singleShot(RELEASE_DELAY_MS, [=](){
                             simulateKeyPress(it->second, true);
                         });
@@ -128,7 +133,7 @@ void SimulateTask::releaseAllKey(QList<MappingRelation*> pressBtnList){
                 default:{
                     // 释放该位置的按键
                     simulateKeyPress(it->second, true);
-                    }
+                }
                 }
 
             }else{
@@ -141,7 +146,7 @@ void SimulateTask::releaseAllKey(QList<MappingRelation*> pressBtnList){
                     // 模拟按下
                     simulateXboxKeyPress(NormalButton, it->second, 0, false);
                     QMetaObject::invokeMethod(QCoreApplication::instance(), [=](){
-                        //释放按键
+                            //释放按键
                         QTimer::singleShot(RELEASE_DELAY_MS, [=](){
                             simulateXboxKeyPress(NormalButton, it->second, 0, true);
                         });
@@ -458,7 +463,7 @@ void SimulateTask::doWork(){
 
     while(getIsRunning()){
         // 轮询设备状态
-        auto res = getInputState(false);
+        auto res = getInputState(false, handleMultiBtnVector);
 
         // 对res进行处理
         res = handleResult(res);

--- a/simulate_task.h
+++ b/simulate_task.h
@@ -30,6 +30,7 @@ private:
     //hid_device *handle;// 当前设备的连接句柄
     std::vector<MappingRelation*> *mappingList;// 已配置的按键映射列表
     std::map<std::string, short> handleMap;// 设备按键对应键盘扫描码map
+    std::vector<MappingRelation> handleMultiBtnVector;// 设备多个按键对应键盘扫描码map
 
     std::map<std::string, short> keyHoldingMap;// 记录按键一直按着的map
 


### PR DESCRIPTION
Hello啊，本分支增加了“多按键映射功能“，方便DIY转向灯玩家。请见截图&提交的代码。
其次，修改了用户界面，移除表头“映射成”，使其能显示更长的按键组合名称。

- 需要注意的是，多按键映射功能依赖的是 dev_btn_value ，为了兼容之前版本默认为0，代码有进行处理，但还得多验证一下；建议用户使用这个功能还是重新配置文件。

- 修改UI后截图：
![image](https://github.com/user-attachments/assets/56bd670f-f4fe-4808-8a34-0d3316d4f553)

- 修改UI前截图：
![image](https://github.com/user-attachments/assets/439e16a4-3d28-4d2f-a715-a9a60447a34f)
