### PR TITLE
[fix]修复strToButtonsValueType函数，不调用stoi()，增加空字符串判断以避免异常

### DIFF
--- a/mapping_relation.h
+++ b/mapping_relation.h
@@ -52,12 +52,14 @@ public:
     }
 
     static BUTTONS_VALUE_TYPE strToButtonsValueType(const std::string& str) {
-        // BUTTONS_VALUE_TYPE result = 0;
-        // for (char c : str) {
-        //     result = result * 10 + (c - '0');
-        // }
-        // return result;
-        return std::stoi(str);
+        if (str.empty()) {
+            return 0;
+        }
+        BUTTONS_VALUE_TYPE result = 0;
+        for (char c : str) {
+            result = result * 10 + (c - '0');
+        }
+        return result;
     }
 
     static std::string buttonsValueTypeToStr(BUTTONS_VALUE_TYPE value) {


### PR DESCRIPTION
Hello啊，本分支修复转换ButtonsValueType错误”。请见截图&提交的代码。
- 修复前：
![image](https://github.com/user-attachments/assets/ac91a734-db08-4123-a3ff-ffd8313fc154)
- 修复后：
![image](https://github.com/user-attachments/assets/4c6e463f-9f9f-49dd-8a1c-0680737a3b59)

