### PR TITLE
增加 组合按键映射优先映射且只映射最长组合键 的可配置选项

### DIFF
--- a/AssistFuncWindow.cpp
+++ b/AssistFuncWindow.cpp
@@ -48,6 +48,11 @@ AssistFuncWindow::AssistFuncWindow(QWidget *parent)
         pushToQueue("开启 打开软件后立即开启映射");
         ui->checkBox_2->setChecked(true);
     }
+
+    if(SYSTEM_enableOnlyLongestMapping){
+        pushToQueue("开启 启用最长组合键优先模式");
+        ui->checkBox_3->setChecked(true);
+    }
 }
 
 AssistFuncWindow::~AssistFuncWindow()
@@ -60,6 +65,11 @@ bool AssistFuncWindow::getEnableMappingAfterOpening()
     return SYSTEM_enableMappingAfterOpening;
 }
 
+bool AssistFuncWindow::getEnableOnlyLongestMapping()
+{
+    return SYSTEM_enableOnlyLongestMapping;
+}
+
 void AssistFuncWindow::saveSettings(){
     // 创建一个 QFile 对象，并打开文件进行写入
     QFile file2(appDataDirPath + ASSIST_FUNC_SETTINGS);  // 文件路径可以是绝对路径或相对路径
@@ -68,6 +78,7 @@ void AssistFuncWindow::saveSettings(){
 
     text2.append("\n\t\"ETS2_enableAutoCancelHandbrake\":").append(ui->checkBox->isChecked() ? "true" : "false").append(",").append("\n");
     text2.append("\n\t\"SYSTEM_enableMappingAfterOpening\":").append(ui->checkBox_2->isChecked() ? "true" : "false").append(",").append("\n");
+    text2.append("\n\t\"SYSTEM_enableOnlyLongestMapping\":").append(ui->checkBox_3->isChecked() ? "true" : "false").append(",").append("\n");
     text2.append("\n\t\"ETS2_installPath\":").append("\"" + ETS2InstallPath + "\"").append("\n");
     text2.append("}");
     if (file2.open(QIODevice::WriteOnly | QIODevice::Text)) {
@@ -105,8 +116,10 @@ void AssistFuncWindow::loadSettings(){
     // 读取信息
     bool enableETS2AutoCancelHandbrake = (jsonObj["ETS2_enableAutoCancelHandbrake"] != QJsonValue::Undefined) ? jsonObj["ETS2_enableAutoCancelHandbrake"].toBool() : false;
     bool enableAutoStartMapping = (jsonObj["SYSTEM_enableMappingAfterOpening"] != QJsonValue::Undefined) ? jsonObj["SYSTEM_enableMappingAfterOpening"].toBool() : false;
+    bool enableOnlyLongestMapping = (jsonObj["SYSTEM_enableOnlyLongestMapping"] != QJsonValue::Undefined) ? jsonObj["SYSTEM_enableOnlyLongestMapping"].toBool() : false;
     this->ETS2_enableAutoCancelHandbrake = enableETS2AutoCancelHandbrake;
     this->SYSTEM_enableMappingAfterOpening = enableAutoStartMapping;
+    this->SYSTEM_enableOnlyLongestMapping = enableOnlyLongestMapping;
     // 欧卡2安装路径
     QString ets2Path = (jsonObj["ETS2_installPath"]!= QJsonValue::Undefined) ? jsonObj["ETS2_installPath"].toString() : "";
     if(!ets2Path.isEmpty()){
@@ -284,3 +297,9 @@ void AssistFuncWindow::on_checkBox_2_clicked()
 {
     unsave();
 }
+
+void AssistFuncWindow::on_checkBox_3_clicked()
+{
+    unsave();
+}
+

--- a/AssistFuncWindow.cpp
+++ b/AssistFuncWindow.cpp
@@ -10,6 +10,10 @@
 #include<QFileDialog>
 #include<QTimer>
 
+bool AssistFuncWindow::ETS2_enableAutoCancelHandbrake = false;
+bool AssistFuncWindow::SYSTEM_enableMappingAfterOpening = false;
+bool AssistFuncWindow::SYSTEM_enableOnlyLongestMapping = false;
+
 AssistFuncWindow::AssistFuncWindow(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::AssistFuncWindow)

--- a/AssistFuncWindow.h
+++ b/AssistFuncWindow.h
@@ -20,6 +20,7 @@ public:
     ~AssistFuncWindow();
 
     bool getEnableMappingAfterOpening();
+    bool getEnableOnlyLongestMapping();
 
 signals:
     void stopWork();
@@ -37,6 +38,8 @@ private slots:
 
     void on_checkBox_2_clicked();
 
+    void on_checkBox_3_clicked();
+
 private:
     Ui::AssistFuncWindow *ui;
 
@@ -46,6 +49,7 @@ private:
 
     bool ETS2_enableAutoCancelHandbrake = false;// 欧卡2辅助功能_开启自动解除手刹
     bool SYSTEM_enableMappingAfterOpening = false;// 映射软件的系统功能_开启软件后立即开启映射
+    bool SYSTEM_enableOnlyLongestMapping = false;// 组合键按下时只执行组合键映射，不执行对应子键映射
 
     void scanETS2InstallPath();// 扫描欧卡2安装路径
 

--- a/AssistFuncWindow.h
+++ b/AssistFuncWindow.h
@@ -19,8 +19,8 @@ public:
     explicit AssistFuncWindow(QWidget *parent = nullptr);
     ~AssistFuncWindow();
 
-    bool getEnableMappingAfterOpening();
-    bool getEnableOnlyLongestMapping();
+    static bool getEnableMappingAfterOpening();
+    static bool getEnableOnlyLongestMapping();
 
 signals:
     void stopWork();
@@ -47,9 +47,9 @@ private:
 
     QString ETS2InstallPath;// 欧卡2安装目录
 
-    bool ETS2_enableAutoCancelHandbrake = false;// 欧卡2辅助功能_开启自动解除手刹
-    bool SYSTEM_enableMappingAfterOpening = false;// 映射软件的系统功能_开启软件后立即开启映射
-    bool SYSTEM_enableOnlyLongestMapping = false;// 组合键按下时只执行组合键映射，不执行对应子键映射
+    static bool ETS2_enableAutoCancelHandbrake;// 欧卡2辅助功能_开启自动解除手刹
+    static bool SYSTEM_enableMappingAfterOpening;// 映射软件的系统功能_开启软件后立即开启映射
+    static bool SYSTEM_enableOnlyLongestMapping;// 组合键按下时只执行组合键映射，不执行对应子键映射
 
     void scanETS2InstallPath();// 扫描欧卡2安装路径
 

--- a/AssistFuncWindow.ui
+++ b/AssistFuncWindow.ui
@@ -155,6 +155,22 @@
        <enum>Qt::Orientation::Horizontal</enum>
       </property>
      </widget>
+     <widget class="QCheckBox" name="checkBox_3">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>180</y>
+        <width>491</width>
+        <height>19</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string>组合键按下时只执行组合键映射，不执行对应子键映射</string>
+      </property>
+      <property name="text">
+       <string>启用最长组合键优先模式</string>
+      </property>
+     </widget>
     </widget>
    </widget>
    <widget class="QPushButton" name="pushButton">

--- a/BigKey.hpp
+++ b/BigKey.hpp
@@ -33,7 +33,7 @@ class BigKey {
     friend BigKey operator&=(BigKey&, const BigKey&);  // 按位与重载
     friend BigKey operator|=(BigKey&, const BigKey&);  // 按位或重载
 
-            // 比较重载
+    // 比较重载
     friend bool operator==(const BigKey&, const BigKey&);  // 等于重载
     friend bool operator!=(const BigKey&, const BigKey&);  // 不等于重载
 
@@ -41,7 +41,7 @@ class BigKey {
     friend bool operator&&(const BigKey&, const bool&);    // 逻辑与重载
     friend bool operator&&(const bool&, const BigKey&);    // 逻辑与重载
 
-            // 输入输出重载
+    // 输入输出重载
     friend ostream& operator<<(ostream&, const BigKey&);  // 输出重载
     friend istream& operator>>(istream&, BigKey&);        // 输入重载
 #if ENABLE_QT
@@ -56,7 +56,7 @@ public:
     BigKey operator=(const BigKey&);      // 赋值函数
     BigKey operator=(BigKey&&) noexcept;  // 移动赋值
 
-            // 转换为字符串
+    // 转换为字符串
     string toString() const;              // decimalNum 用于控制小数位数，赋值为0时小数部分全部输出
     void setBit(size_t pos, bool value);  // 设置按键值
     void clear();                         // 清空按键值
@@ -69,12 +69,12 @@ public:
 #define BIGKEY_ZERO BigKey::ZERO()
 
 private:
-#define BIGKEY_NUMBER 1  // 128位按键值，使用uint32_t数组存储
-#define BIGKEY_TYPE_INTERNAL __uint128_t  // 内部存储类型
+#define BIGKEY_NUMBER 2  // 128位按键值，使用数组存储
+#define BIGKEY_TYPE_INTERNAL uint64_t  // 内部存储类型
 
-#define MAX_BUTTONS (BIGKEY_NUMBER * (sizeof(BIGKEY_TYPE_INTERNAL) * 8))  // 128位按键值，使用uint32_t数组存储
+#define MAX_BUTTONS (BIGKEY_NUMBER * (sizeof(BIGKEY_TYPE_INTERNAL) * 8))
 
-    BIGKEY_TYPE_INTERNAL key[BIGKEY_NUMBER];  // 128位按键值，使用uint32_t数组存储
+    BIGKEY_TYPE_INTERNAL key[BIGKEY_NUMBER];  // 128位按键值，使用数组存储
 };
 
 inline BigKey::BigKey()  // 默认构造函数
@@ -158,9 +158,9 @@ inline void BigKey::setBit(size_t pos, bool value) {
     }
     // 设置按键值
     if (value) {
-        key[pos / (sizeof(BIGKEY_TYPE_INTERNAL) * 8)] |= (1 << (pos % (sizeof(BIGKEY_TYPE_INTERNAL) * 8)));  // 设置为1
+        key[pos / (sizeof(BIGKEY_TYPE_INTERNAL) * 8)] |= ((BIGKEY_TYPE_INTERNAL)1 << (pos % (sizeof(BIGKEY_TYPE_INTERNAL) * 8)));  // 设置为1
     } else {
-        key[pos / (sizeof(BIGKEY_TYPE_INTERNAL) * 8)] &= ~(1 << (pos % (sizeof(BIGKEY_TYPE_INTERNAL) * 8)));  // 设置为0
+        key[pos / (sizeof(BIGKEY_TYPE_INTERNAL) * 8)] &= ~((BIGKEY_TYPE_INTERNAL)1 << (pos % (sizeof(BIGKEY_TYPE_INTERNAL) * 8)));  // 设置为0
     }
 }
 

--- a/BigKey.hpp
+++ b/BigKey.hpp
@@ -1,0 +1,250 @@
+#pragma once
+#include <QDebug>
+#include <algorithm>
+#include <cmath>
+#include <deque>
+#include <iostream>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using std::deque;
+using std::istream;
+using std::ostream;
+using std::string;
+using std::vector;
+
+#define MAX_BUTTONS 128
+
+// 参考开源库 高精度浮点类：https://gitee.com/chenjjian/bigfloat/blob/master/BigFloat.h
+
+class BigKey {
+    // 基本运算符重载
+    const friend BigKey operator&(const BigKey&, const BigKey&);  // 按位与重载
+    const friend BigKey operator|(const BigKey&, const BigKey&);  // 按位或重载
+    const friend BigKey operator~(BigKey&);                       // 取反重载
+
+    friend BigKey operator&=(BigKey&, const BigKey&);  // 按位与重载
+    friend BigKey operator|=(BigKey&, const BigKey&);  // 按位或重载
+
+    // 比较重载
+    const friend bool operator==(const BigKey&, const BigKey&);  // 等于重载
+    const friend bool operator!=(const BigKey&, const BigKey&);  // 不等于重载
+
+    friend bool operator&&(const BigKey&, const BigKey&);  // 逻辑与重载
+    friend bool operator&&(const BigKey&, const bool&);    // 逻辑与重载
+    friend bool operator&&(const bool&, const BigKey&);    // 逻辑与重载
+
+    // 输入输出重载
+    friend ostream& operator<<(ostream&, const BigKey&);    // 输出重载
+    friend istream& operator>>(istream&, BigKey&);          // 输入重载
+    friend QDebug operator<<(QDebug dbg, const BigKey& p);  // 调试重载 （注意，不是返回引用）
+
+#define BIGKEY_ZERO BigKey::ZERO()
+
+public:
+    BigKey();
+    BigKey(const BigKey&);                //
+    BigKey(const string&);                // 用一个字符串构造
+    BigKey(BigKey&&) noexcept;            // 移动构造
+    BigKey operator=(const BigKey&);      // 赋值函数
+    BigKey operator=(BigKey&&) noexcept;  // 移动赋值
+
+    // 转换为字符串
+    string toString() const;           // decimalNum 用于控制小数位数，赋值为0时小数部分全部输出
+    void setBit(int pos, bool value);  // 设置按键值
+    void clear();                      // 清空按键值
+
+    static const BigKey& ZERO() {
+        static BigKey zero;
+        return zero;
+    };
+
+private:
+    string key;
+};
+
+inline BigKey::BigKey()  // 默认构造函数
+{
+    key= string(MAX_BUTTONS, '0');  // 初始化为128个0
+}
+
+inline BigKey::BigKey(const BigKey& num) {
+    key= num.key;  // 交换字符串
+}
+
+inline BigKey::BigKey(BigKey&& num) noexcept  // 移动构造
+{
+    key.swap(num.key);  // 交换字符串
+}
+
+inline BigKey BigKey::operator=(const BigKey& num)  // 赋值（拷贝）操作
+{
+    key= num.key;  // 直接赋值
+    return *this;
+}
+
+inline BigKey BigKey::operator=(BigKey&& num) noexcept {
+    key= num.key;  // 直接赋值
+    return *this;
+}
+
+inline BigKey operator&=(BigKey& num1, const BigKey& num2) {
+    for (int i= 0; i < MAX_BUTTONS; i++) {
+        if (num1.key[i] == '1' && num2.key[i] == '1') {
+            num1.key[i]= '1';
+        } else {
+            num1.key[i]= '0';
+        }
+    }
+    return num1;
+}
+
+inline BigKey operator|=(BigKey& num1, const BigKey& num2) {
+    for (int i= 0; i < MAX_BUTTONS; i++) {
+        if (num1.key[i] == '1' || num2.key[i] == '1') {
+            num1.key[i]= '1';
+        } else {
+            num1.key[i]= '0';
+        }
+    }
+    return num1;
+}
+
+inline const BigKey operator&(const BigKey& num1, const BigKey& num2)  // 按位与重载
+{
+    BigKey temp;
+    for (int i= 0; i < MAX_BUTTONS; i++) {
+        if (num1.key[i] == '1' && num2.key[i] == '1') {
+            temp.key[i]= '1';
+        } else {
+            temp.key[i]= '0';
+        }
+    }
+    return temp;
+}
+
+inline const BigKey operator|(const BigKey& num1, const BigKey& num2)  // 按位或重载
+{
+    BigKey temp(num1);
+    for (int i= 0; i < MAX_BUTTONS; i++) {
+        if (num1.key[i] == '1' || num2.key[i] == '1') {
+            temp.key[i]= '1';
+        } else {
+            temp.key[i]= '0';
+        }
+    }
+    return temp;
+}
+
+inline const BigKey operator~(BigKey& num1) {
+    // 取反重载
+    BigKey temp(num1);
+    for (int i= 0; i < MAX_BUTTONS; i++) {
+        if (num1.key[i] == '1') {
+            temp.key[i]= '0';
+        } else {
+            temp.key[i]= '1';
+        }
+    }
+    return temp;
+}
+
+inline void BigKey::setBit(int pos, bool value) {
+    if (pos < 0 || pos >= MAX_BUTTONS) {
+        throw std::out_of_range("Position out of range");
+    }
+    if (value) {
+        key[pos]= '1';  // 设置为1
+    } else {
+        key[pos]= '0';  // 设置为0
+    }
+}
+
+inline void BigKey::clear() {
+    // 清空按键值
+    key= string(MAX_BUTTONS, '0');
+}
+
+inline bool operator&&(const BigKey& num1, const BigKey& num2) {
+    // 逻辑与重载
+    if (num1.key.find('1') != string::npos && num2.key.find('1') != string::npos) {
+        return true;  // 都有1
+    }
+    return false;
+}
+
+inline bool operator&&(const BigKey& num1, const bool& num2) {
+    // 逻辑与重载
+    if (num2 == false) {
+        return false;  // 如果num2为false，直接返回false
+    }
+    if (num1.key.find('1') != string::npos) {
+        return true;  // 都有1
+    }
+    return false;
+}
+
+inline bool operator&&(const bool& num1, const BigKey& num2) {
+    // 逻辑与重载
+    if (num1 == false) {
+        return false;  // 如果num2为false，直接返回false
+    }
+    if (num2.key.find('1') != string::npos) {
+        return true;  // 都有1
+    }
+    return false;
+}
+
+inline string BigKey::toString() const {
+    return key;  // 返回字符串
+}
+
+inline BigKey::BigKey(const string& num)  // 用字符串初始化
+{
+    key= num;  // 直接赋值
+    // 检查字符串长度是否超过128位
+    if (key.length() > MAX_BUTTONS) {
+        throw std::out_of_range("String length exceeds maximum size of 128 bits");
+    }
+    key.resize(MAX_BUTTONS, '0');  // 补齐到128位
+}
+
+inline ostream& operator<<(ostream& out, const BigKey& num)  // 输出重载
+{
+    for (int i= MAX_BUTTONS - 1; i >= 0; i--)  // 输出整数部分
+    {
+        out << (char)(num.key[i]);
+    }
+    return out;
+}
+
+inline QDebug operator<<(QDebug dbg, const BigKey& num)  // 输出重载 （注意，不是返回引用）
+{
+    QString str= "";
+    for (int i= MAX_BUTTONS - 1; i >= 0; i--)  // 输出整数部分
+    {
+        str+= (char)(num.key[i]);
+    }
+    dbg << qPrintable(str);  // 打印时没有双引号
+    return dbg;
+}
+
+inline istream& operator>>(istream& in, BigKey& num)  // 输入重载
+{
+    string str;
+    in >> str;
+    num= BigKey(str);
+    return in;
+}
+
+const inline bool operator==(const BigKey& num1, const BigKey& num2)  // 等于重载
+{
+    return num1.key == num2.key;  // 比较字符串是否相等
+}
+
+const inline bool operator!=(const BigKey& num1, const BigKey& num2)  // 不等于重载
+{
+    return !(num1 == num2);  // 调用等于重载函数
+}

--- a/BigKey.hpp
+++ b/BigKey.hpp
@@ -29,8 +29,8 @@ class BigKey {
     friend BigKey operator|=(BigKey&, const BigKey&);  // 按位或重载
 
     // 比较重载
-    const friend bool operator==(const BigKey&, const BigKey&);  // 等于重载
-    const friend bool operator!=(const BigKey&, const BigKey&);  // 不等于重载
+    friend bool operator==(const BigKey&, const BigKey&);  // 等于重载
+    friend bool operator!=(const BigKey&, const BigKey&);  // 不等于重载
 
     friend bool operator&&(const BigKey&, const BigKey&);  // 逻辑与重载
     friend bool operator&&(const BigKey&, const bool&);    // 逻辑与重载
@@ -239,12 +239,12 @@ inline istream& operator>>(istream& in, BigKey& num)  // 输入重载
     return in;
 }
 
-const inline bool operator==(const BigKey& num1, const BigKey& num2)  // 等于重载
+inline bool operator==(const BigKey& num1, const BigKey& num2)  // 等于重载
 {
     return num1.key == num2.key;  // 比较字符串是否相等
 }
 
-const inline bool operator!=(const BigKey& num1, const BigKey& num2)  // 不等于重载
+inline bool operator!=(const BigKey& num1, const BigKey& num2)  // 不等于重载
 {
     return !(num1 == num2);  // 调用等于重载函数
 }

--- a/BigKey.hpp
+++ b/BigKey.hpp
@@ -69,8 +69,8 @@ public:
 #define BIGKEY_ZERO BigKey::ZERO()
 
 private:
-#define BIGKEY_NUMBER 4  // 128位按键值，使用uint32_t数组存储
-#define BIGKEY_TYPE_INTERNAL uint32_t  // 内部存储类型
+#define BIGKEY_NUMBER 1  // 128位按键值，使用uint32_t数组存储
+#define BIGKEY_TYPE_INTERNAL __uint128_t  // 内部存储类型
 
 #define MAX_BUTTONS (BIGKEY_NUMBER * (sizeof(BIGKEY_TYPE_INTERNAL) * 8))  // 128位按键值，使用uint32_t数组存储
 

--- a/BigKey.hpp
+++ b/BigKey.hpp
@@ -1,11 +1,13 @@
 #pragma once
-#include <QDebug>
+#define ENABLE_QT true
+
 #include <algorithm>
 #include <cmath>
 #include <deque>
 #include <iostream>
 #include <regex>
 #include <stdexcept>
+#include <stdint.h>
 #include <string>
 #include <vector>
 
@@ -15,9 +17,12 @@ using std::ostream;
 using std::string;
 using std::vector;
 
-#define MAX_BUTTONS 128
+#if ENABLE_QT
+#include <QDebug>
+#endif
 
-// 参考开源库 高精度浮点类：https://gitee.com/chenjjian/bigfloat/blob/master/BigFloat.h
+// 参考开源库
+// 高精度浮点类：https://gitee.com/chenjjian/bigfloat/blob/master/BigFloat.h
 
 class BigKey {
     // 基本运算符重载
@@ -28,7 +33,7 @@ class BigKey {
     friend BigKey operator&=(BigKey&, const BigKey&);  // 按位与重载
     friend BigKey operator|=(BigKey&, const BigKey&);  // 按位或重载
 
-    // 比较重载
+            // 比较重载
     friend bool operator==(const BigKey&, const BigKey&);  // 等于重载
     friend bool operator!=(const BigKey&, const BigKey&);  // 不等于重载
 
@@ -36,12 +41,12 @@ class BigKey {
     friend bool operator&&(const BigKey&, const bool&);    // 逻辑与重载
     friend bool operator&&(const bool&, const BigKey&);    // 逻辑与重载
 
-    // 输入输出重载
-    friend ostream& operator<<(ostream&, const BigKey&);    // 输出重载
-    friend istream& operator>>(istream&, BigKey&);          // 输入重载
-    friend QDebug operator<<(QDebug dbg, const BigKey& p);  // 调试重载 （注意，不是返回引用）
-
-#define BIGKEY_ZERO BigKey::ZERO()
+            // 输入输出重载
+    friend ostream& operator<<(ostream&, const BigKey&);  // 输出重载
+    friend istream& operator>>(istream&, BigKey&);        // 输入重载
+#if ENABLE_QT
+    friend QDebug operator<<(QDebug dbg, const BigKey& p);  // 调试重载   （注意，不是返回引用）
+#endif
 
 public:
     BigKey();
@@ -51,89 +56,89 @@ public:
     BigKey operator=(const BigKey&);      // 赋值函数
     BigKey operator=(BigKey&&) noexcept;  // 移动赋值
 
-    // 转换为字符串
-    string toString() const;           // decimalNum 用于控制小数位数，赋值为0时小数部分全部输出
-    void setBit(int pos, bool value);  // 设置按键值
-    void clear();                      // 清空按键值
+            // 转换为字符串
+    string toString() const;              // decimalNum 用于控制小数位数，赋值为0时小数部分全部输出
+    void setBit(size_t pos, bool value);  // 设置按键值
+    void clear();                         // 清空按键值
 
     static const BigKey& ZERO() {
         static BigKey zero;
         return zero;
     };
 
+#define BIGKEY_ZERO BigKey::ZERO()
+
 private:
-    string key;
+#define BIGKEY_NUMBER 4  // 128位按键值，使用uint32_t数组存储
+#define BIGKEY_TYPE_INTERNAL uint32_t  // 内部存储类型
+
+#define MAX_BUTTONS (BIGKEY_NUMBER * (sizeof(BIGKEY_TYPE_INTERNAL) * 8))  // 128位按键值，使用uint32_t数组存储
+
+    BIGKEY_TYPE_INTERNAL key[BIGKEY_NUMBER];  // 128位按键值，使用uint32_t数组存储
 };
 
 inline BigKey::BigKey()  // 默认构造函数
 {
-    key= string(MAX_BUTTONS, '0');  // 初始化为128个0
+    this->clear();  // 清空按键值
 }
 
 inline BigKey::BigKey(const BigKey& num) {
-    key= num.key;  // 交换字符串
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        key[i] = num.key[i];  // 直接赋值
+    }
 }
 
-inline BigKey::BigKey(BigKey&& num) noexcept  // 移动构造
-{
-    key.swap(num.key);  // 交换字符串
+// 移动构造
+inline BigKey::BigKey(BigKey&& num) noexcept {
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        key[i] = num.key[i];  // 直接赋值
+    }
 }
-
-inline BigKey BigKey::operator=(const BigKey& num)  // 赋值（拷贝）操作
-{
-    key= num.key;  // 直接赋值
+// 赋值（拷贝）操作
+inline BigKey BigKey::operator=(const BigKey& num) {
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        key[i] = num.key[i];  // 直接赋值
+    }
     return *this;
 }
 
 inline BigKey BigKey::operator=(BigKey&& num) noexcept {
-    key= num.key;  // 直接赋值
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        key[i] = num.key[i];  // 直接赋值
+    }
     return *this;
 }
 
 inline BigKey operator&=(BigKey& num1, const BigKey& num2) {
-    for (int i= 0; i < MAX_BUTTONS; i++) {
-        if (num1.key[i] == '1' && num2.key[i] == '1') {
-            num1.key[i]= '1';
-        } else {
-            num1.key[i]= '0';
-        }
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        num1.key[i] &= num2.key[i];  // 按位与
     }
     return num1;
 }
 
 inline BigKey operator|=(BigKey& num1, const BigKey& num2) {
-    for (int i= 0; i < MAX_BUTTONS; i++) {
-        if (num1.key[i] == '1' || num2.key[i] == '1') {
-            num1.key[i]= '1';
-        } else {
-            num1.key[i]= '0';
-        }
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        num1.key[i] |= num2.key[i];  // 按位或
     }
     return num1;
 }
 
-inline const BigKey operator&(const BigKey& num1, const BigKey& num2)  // 按位与重载
+inline const BigKey operator&(const BigKey& num1,
+                              const BigKey& num2)  // 按位与重载
 {
     BigKey temp;
-    for (int i= 0; i < MAX_BUTTONS; i++) {
-        if (num1.key[i] == '1' && num2.key[i] == '1') {
-            temp.key[i]= '1';
-        } else {
-            temp.key[i]= '0';
-        }
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        temp.key[i] = num1.key[i] & num2.key[i];  // 按位与
     }
     return temp;
 }
 
-inline const BigKey operator|(const BigKey& num1, const BigKey& num2)  // 按位或重载
+inline const BigKey operator|(const BigKey& num1,
+                              const BigKey& num2)  // 按位或重载
 {
     BigKey temp(num1);
-    for (int i= 0; i < MAX_BUTTONS; i++) {
-        if (num1.key[i] == '1' || num2.key[i] == '1') {
-            temp.key[i]= '1';
-        } else {
-            temp.key[i]= '0';
-        }
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        temp.key[i] = num1.key[i] | num2.key[i];  // 按位或
     }
     return temp;
 }
@@ -141,38 +146,43 @@ inline const BigKey operator|(const BigKey& num1, const BigKey& num2)  // 按位
 inline const BigKey operator~(BigKey& num1) {
     // 取反重载
     BigKey temp(num1);
-    for (int i= 0; i < MAX_BUTTONS; i++) {
-        if (num1.key[i] == '1') {
-            temp.key[i]= '0';
-        } else {
-            temp.key[i]= '1';
-        }
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        temp.key[i] = ~num1.key[i];  // 取反
     }
     return temp;
 }
 
-inline void BigKey::setBit(int pos, bool value) {
-    if (pos < 0 || pos >= MAX_BUTTONS) {
+inline void BigKey::setBit(size_t pos, bool value) {
+    if (pos > MAX_BUTTONS) {
         throw std::out_of_range("Position out of range");
     }
+    // 设置按键值
     if (value) {
-        key[pos]= '1';  // 设置为1
+        key[pos / (sizeof(BIGKEY_TYPE_INTERNAL) * 8)] |= (1 << (pos % (sizeof(BIGKEY_TYPE_INTERNAL) * 8)));  // 设置为1
     } else {
-        key[pos]= '0';  // 设置为0
+        key[pos / (sizeof(BIGKEY_TYPE_INTERNAL) * 8)] &= ~(1 << (pos % (sizeof(BIGKEY_TYPE_INTERNAL) * 8)));  // 设置为0
     }
 }
 
 inline void BigKey::clear() {
     // 清空按键值
-    key= string(MAX_BUTTONS, '0');
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        key[i] = 0;  // 初始化为0
+    }
 }
 
 inline bool operator&&(const BigKey& num1, const BigKey& num2) {
     // 逻辑与重载
-    if (num1.key.find('1') != string::npos && num2.key.find('1') != string::npos) {
-        return true;  // 都有1
+    bool flag1 = false, flag2 = false;
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        if (num1.key[i]) {
+            flag1 = true;  // num1有1
+        }
+        if (num2.key[i]) {
+            flag2 = true;  // num2有1
+        }
     }
-    return false;
+    return flag1 && flag2;
 }
 
 inline bool operator&&(const BigKey& num1, const bool& num2) {
@@ -180,68 +190,74 @@ inline bool operator&&(const BigKey& num1, const bool& num2) {
     if (num2 == false) {
         return false;  // 如果num2为false，直接返回false
     }
-    if (num1.key.find('1') != string::npos) {
-        return true;  // 都有1
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        if (num1.key[i]) {
+            return true;  // num1有1
+        }
     }
     return false;
 }
 
 inline bool operator&&(const bool& num1, const BigKey& num2) {
-    // 逻辑与重载
-    if (num1 == false) {
-        return false;  // 如果num2为false，直接返回false
-    }
-    if (num2.key.find('1') != string::npos) {
-        return true;  // 都有1
-    }
-    return false;
+    return num2 && num1;  // 调用上面的重载函数
 }
 
 inline string BigKey::toString() const {
-    return key;  // 返回字符串
+    // 转换为字符串
+    string str = "";
+    // 显示为2进制，前面要补0
+    for (int i = BIGKEY_NUMBER - 1; i >= 0; i--) {
+        string temp = std::bitset<sizeof(BIGKEY_TYPE_INTERNAL) * 8>(key[i]).to_string();  // 转换为2进制
+        str += temp;                                                                      // 拼接字符串
+    }
+    return str;
 }
 
 inline BigKey::BigKey(const string& num)  // 用字符串初始化
 {
-    key= num;  // 直接赋值
-    // 检查字符串长度是否超过128位
-    if (key.length() > MAX_BUTTONS) {
-        throw std::out_of_range("String length exceeds maximum size of 128 bits");
+    if (num.size() > MAX_BUTTONS) {
+        std::string errMsg = "String size exceeds maximum buttons " + std::to_string(num.size());
+        throw std::out_of_range(errMsg);
     }
-    key.resize(MAX_BUTTONS, '0');  // 补齐到128位
+    this->clear();  // 清空按键值
+    for (size_t i = 0; i < num.size(); i++) {
+        if (num[i] != '0') {
+            this->setBit(num.size() - i - 1, true);  // 设置按键值
+        }
+    }
 }
 
 inline ostream& operator<<(ostream& out, const BigKey& num)  // 输出重载
 {
-    for (int i= MAX_BUTTONS - 1; i >= 0; i--)  // 输出整数部分
-    {
-        out << (char)(num.key[i]);
-    }
+    out << num.toString();  // 打印时没有双引号
     return out;
 }
 
+#if ENABLE_QT
 inline QDebug operator<<(QDebug dbg, const BigKey& num)  // 输出重载 （注意，不是返回引用）
 {
-    QString str= "";
-    for (int i= MAX_BUTTONS - 1; i >= 0; i--)  // 输出整数部分
-    {
-        str+= (char)(num.key[i]);
-    }
-    dbg << qPrintable(str);  // 打印时没有双引号
+    QString str = num.toString().data();  // 转换为QString
+    dbg << qPrintable(str);               // 打印时没有双引号
     return dbg;
 }
+#endif
 
 inline istream& operator>>(istream& in, BigKey& num)  // 输入重载
 {
     string str;
     in >> str;
-    num= BigKey(str);
+    num = BigKey(str);
     return in;
 }
 
 inline bool operator==(const BigKey& num1, const BigKey& num2)  // 等于重载
 {
-    return num1.key == num2.key;  // 比较字符串是否相等
+    for (int i = 0; i < BIGKEY_NUMBER; i++) {
+        if (num1.key[i] != num2.key[i]) {
+            return false;  // 不相等
+        }
+    }
+    return true;  // 相等
 }
 
 inline bool operator!=(const BigKey& num1, const BigKey& num2)  // 不等于重载

--- a/global.cpp
+++ b/global.cpp
@@ -316,7 +316,6 @@ QList<MappingRelation*> getInputState(bool enableLog, std::vector<MappingRelatio
                     if ((multiBtnBitValue) && ((multiBtnBitValue & btnBitValue) == multiBtnBitValue)) {
                         // 找到对应的按键, 进行映射
                         btnBitValue &= (~multiBtnBitValue);  // 清除当前按键的值
-                        qDebug() << btnBitValue;
                         MappingRelation *mapping = new MappingRelation(multiBtn.dev_btn_name, WHEEL_BUTTON, 0, 0, "");
                         mapping->setBtnBitValue(multiBtnBitValue);  // 设置按键值
                         list.append(mapping);

--- a/global.cpp
+++ b/global.cpp
@@ -4,6 +4,7 @@
 #include<QMutexLocker>
 #include<QMutex>
 #include<QDateTime>
+#include "AssistFuncWindow.h"
 
 bool isRuning = false;
 bool isXboxMode = false;
@@ -315,7 +316,9 @@ QList<MappingRelation*> getInputState(bool enableLog, std::vector<MappingRelatio
                     BUTTONS_VALUE_TYPE multiBtnBitValue = multiBtn.dev_btn_bit_value;
                     if ((multiBtnBitValue) && ((multiBtnBitValue & btnBitValue) == multiBtnBitValue)) {
                         // 找到对应的按键, 进行映射
-                        btnBitValue &= (~multiBtnBitValue);  // 清除当前按键的值
+                        if (AssistFuncWindow::getEnableOnlyLongestMapping()) {
+                            btnBitValue &= (~multiBtnBitValue);  // 清除当前按键的值
+                        }
                         MappingRelation *mapping = new MappingRelation(multiBtn.dev_btn_name, WHEEL_BUTTON, 0, 0, "");
                         mapping->setBtnBitValue(multiBtnBitValue);  // 设置按键值
                         list.append(mapping);

--- a/global.cpp
+++ b/global.cpp
@@ -288,7 +288,7 @@ QList<MappingRelation*> getInputState(bool enableLog, std::vector<MappingRelatio
         // 遍历按键，查看按键是否按下
         std::string btnStr = "";
         BUTTONS_VALUE_TYPE btnBitValue;
-        for (int i = 0; i < MAX_BUTTONS; i++) {
+        for (size_t i = 0; i < MAX_BUTTONS; i++) {
             if (js.rgbButtons[i] & 0x80) {
                 btnStr += "按键" + std::to_string(i) + "+";
                 btnBitValue.setBit(i, true);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -130,7 +130,7 @@ MainWindow::MainWindow(QMainWindow *parent)
 
     this->assistWindow = new AssistFuncWindow();
 
-    if(this->assistWindow->getEnableMappingAfterOpening()){
+    if(AssistFuncWindow::getEnableMappingAfterOpening()){
         on_pushButton_2_clicked();
     }
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -568,7 +568,8 @@ void MainWindow::saveMappingsToFile(std::string filename){
 
             text.append("\"dev_btn_name\":\"" + item->dev_btn_name + "\"").append(", ");
             text.append("\"dev_btn_type\":\"" + item->dev_btn_type + "\"").append(", ");
-            text.append("\"dev_btn_value\":\"" + MappingRelation::buttonsValueTypeToStr(item->dev_btn_value) + "\"").append(", ");
+            text.append("\"dev_btn_value\":\"" + std::to_string(item->dev_btn_value) + "\"").append(", ");
+            text.append("\"dev_btn_bit_value\":\"" + item->dev_btn_bit_value.toString() + "\"").append(", ");
             text.append("\"keyboard_name\":\"" + (item->keyboard_name == "\\" ? "\\\\" : item->keyboard_name) + "\"").append(", ");
             text.append("\"keyboard_value\":" + std::to_string(item->keyboard_value)).append(", ");
             text.append("\"remark\":\"" + item->remark + "\"").append(", ");
@@ -771,10 +772,17 @@ void MainWindow::loadMappingsFile(std::string filename){
                                               : TriggerTypeEnum::Normal;
                 mapping->dev_btn_value = 
                     (jsonObj["dev_btn_value"] != QJsonValue::Undefined && !jsonObj["dev_btn_value"].toString().isEmpty())
-                                              ? MappingRelation::strToButtonsValueType(jsonObj["dev_btn_value"].toString().toStdString())
+                                              ? (jsonObj["dev_btn_value"].toString().toInt())
                                               : 0;
 
-
+                if (jsonObj["dev_btn_bit_value"] != QJsonValue::Undefined && !jsonObj["dev_btn_bit_value"].toString().isEmpty())
+                {
+                    mapping->dev_btn_bit_value = 
+                        (BUTTONS_VALUE_TYPE)(jsonObj["dev_btn_bit_value"].toString().toStdString());
+                }
+                else {
+                    mapping->dev_btn_bit_value.clear();
+                }
 
                 mappingList.push_back(mapping);
             }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -569,7 +569,6 @@ void MainWindow::saveMappingsToFile(std::string filename){
             text.append("\"dev_btn_name\":\"" + item->dev_btn_name + "\"").append(", ");
             text.append("\"dev_btn_type\":\"" + item->dev_btn_type + "\"").append(", ");
             text.append("\"dev_btn_value\":\"" + std::to_string(item->dev_btn_value) + "\"").append(", ");
-            text.append("\"dev_btn_bit_value\":\"" + item->dev_btn_bit_value.toString() + "\"").append(", ");
             text.append("\"keyboard_name\":\"" + (item->keyboard_name == "\\" ? "\\\\" : item->keyboard_name) + "\"").append(", ");
             text.append("\"keyboard_value\":" + std::to_string(item->keyboard_value)).append(", ");
             text.append("\"remark\":\"" + item->remark + "\"").append(", ");
@@ -774,16 +773,6 @@ void MainWindow::loadMappingsFile(std::string filename){
                     (jsonObj["dev_btn_value"] != QJsonValue::Undefined && !jsonObj["dev_btn_value"].toString().isEmpty())
                                               ? (jsonObj["dev_btn_value"].toString().toInt())
                                               : 0;
-
-                if (jsonObj["dev_btn_bit_value"] != QJsonValue::Undefined && !jsonObj["dev_btn_bit_value"].toString().isEmpty())
-                {
-                    mapping->dev_btn_bit_value = 
-                        (BUTTONS_VALUE_TYPE)(jsonObj["dev_btn_bit_value"].toString().toStdString());
-                }
-                else {
-                    mapping->dev_btn_bit_value.clear();
-                }
-
                 mappingList.push_back(mapping);
             }
         }

--- a/mapping_relation.h
+++ b/mapping_relation.h
@@ -2,17 +2,17 @@
 #define MAPPING_RELATION_H
 #include "BtnTriggerTypeEnum.h"
 #include<string>
-
+#include "keyValType.hpp"
 //using namespace std;
-#define BUTTONS_VALUE_TYPE int32_t
-#define MAX_BUTTONS 128
+#define BUTTONS_VALUE_TYPE BigKey
 
 class MappingRelation{
 public:
     int dev_btn_pos; // 设备按键位置
     std::string dev_btn_name;// 设备按键名称
     std::string dev_btn_type;// 设备按键类型(用于区分方向盘的轴和按键)
-    BUTTONS_VALUE_TYPE dev_btn_value; // 设备按键值
+    BUTTONS_VALUE_TYPE dev_btn_bit_value; // 设备按键值
+    int dev_btn_value; // 设备按键值(方向盘的轴和十字键等)
     short keyboard_value;// 键盘按键值
     std::string keyboard_name;// 键盘按键名称
     std::string remark; // 备注
@@ -20,21 +20,21 @@ public:
     TriggerTypeEnum btnTriggerType; // 按键触发类型
 
     MappingRelation(){}
-    MappingRelation(int dev_btn_pos, BUTTONS_VALUE_TYPE dev_btn_value, short keyboard_value, std::string keyboard_name){
+    MappingRelation(int dev_btn_pos, int dev_btn_value, short keyboard_value, std::string keyboard_name){
         this->dev_btn_pos = dev_btn_pos;
         this->dev_btn_value = dev_btn_value;
         this->keyboard_value = keyboard_value;
         this->keyboard_name = keyboard_name;
     }
 
-    MappingRelation(std::string dev_btn_name, BUTTONS_VALUE_TYPE dev_btn_value, short keyboard_value, std::string keyboard_name){
+    MappingRelation(std::string dev_btn_name, int dev_btn_value, short keyboard_value, std::string keyboard_name){
         this->dev_btn_name = dev_btn_name;
         this->dev_btn_value = dev_btn_value;
         this->keyboard_value = keyboard_value;
         this->keyboard_name = keyboard_name;
     }
 
-    MappingRelation(std::string dev_btn_name, std::string dev_btn_type,BUTTONS_VALUE_TYPE dev_btn_value, short keyboard_value, std::string keyboard_name){
+    MappingRelation(std::string dev_btn_name, std::string dev_btn_type, int dev_btn_value, short keyboard_value, std::string keyboard_name){
         this->dev_btn_name = dev_btn_name;
         this->dev_btn_type = dev_btn_type;
         this->dev_btn_value = dev_btn_value;
@@ -42,7 +42,7 @@ public:
         this->keyboard_name = keyboard_name;
     }
 
-    MappingRelation(std::string dev_btn_name, std::string dev_btn_type,BUTTONS_VALUE_TYPE dev_btn_value, short keyboard_value, std::string keyboard_name, TriggerTypeEnum btnTriggerType){
+    MappingRelation(std::string dev_btn_name, std::string dev_btn_type, int dev_btn_value, short keyboard_value, std::string keyboard_name, TriggerTypeEnum btnTriggerType){
         this->dev_btn_name = dev_btn_name;
         this->dev_btn_type = dev_btn_type;
         this->dev_btn_value = dev_btn_value;
@@ -51,31 +51,8 @@ public:
         this->btnTriggerType = btnTriggerType;
     }
 
-    static BUTTONS_VALUE_TYPE strToButtonsValueType(const std::string& str) {
-        // BUTTONS_VALUE_TYPE result = 0;
-        // for (char c : str) {
-        //     result = result * 10 + (c - '0');
-        // }
-        // return result;
-        return std::stoi(str);
-    }
-
-    static std::string buttonsValueTypeToStr(BUTTONS_VALUE_TYPE value) {
-        // std::string result;
-        // while (value > 0) {
-        //     result = static_cast<char>('0' + (value % 10)) + result;
-        //     value /= 10;
-        // }
-        // return result.empty() ? "0" : result;
-        return std::to_string(value);
-    }
-
-    static std::string toBitStr(BUTTONS_VALUE_TYPE value) {
-        std::string bitStr;
-        for (int i = 0; i < sizeof(BUTTONS_VALUE_TYPE) * 8; ++i) {
-            bitStr += (value & (1 << i)) ? '1' : '0';
-        }
-        return bitStr;
+    void setBtnBitValue(BUTTONS_VALUE_TYPE dev_btn_bit_value){
+        this->dev_btn_bit_value = dev_btn_bit_value;
     }
 };
 

--- a/mapping_relation.h
+++ b/mapping_relation.h
@@ -2,7 +2,7 @@
 #define MAPPING_RELATION_H
 #include "BtnTriggerTypeEnum.h"
 #include<string>
-#include "keyValType.hpp"
+#include "BigKey.hpp"
 //using namespace std;
 #define BUTTONS_VALUE_TYPE BigKey
 

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -46,11 +46,16 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
     for(MappingRelation* mapping : *mappingList){
         // 兼容性处理, 如果没有设置按键值, 则根据按键名称设置按键值
         if (mapping->dev_btn_bit_value == BIGKEY_ZERO) {
-            std::string btnStr = mapping->dev_btn_name;
-            if (btnStr.find("按键") != std::string::npos && btnStr.find("+") == std::string::npos) {
-                int index = QString(btnStr.data()).mid(2).toInt(); // 获取按键索引
-                mapping->dev_btn_bit_value.setBit(index, true); // 设置按键值
-                qDebug("%s 按键值为0, 索引: %d, 设置为:0x%s", btnStr.data(), index, mapping->dev_btn_bit_value.toString().data());
+            std::string btn_name = mapping->dev_btn_name;
+            if (btn_name.find("按键") != std::string::npos) {
+                qDebug("%s 按键值为0, 索引: ", btn_name.data());
+                QStringList btnStrList = QString::fromStdString(btn_name).split("+");
+                for (const QString& btn : btnStrList) {
+                    int index = btn.mid(2).toInt(); // 获取按键索引
+                    mapping->dev_btn_bit_value.setBit(index, true); // 设置按键值
+                    qDebug("%d, ", index);
+                }
+                qDebug("设置为:0x%s", mapping->dev_btn_bit_value.toString().data());
             }
         }
 
@@ -64,7 +69,7 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
         }  
     }
 
-    // 对handleMultiBtnVector进行对 dev_btn_name长度的排序, 使得映射按键的名称从长到短排列
+    // 多按键优先级高, 先处理多按键映射,故排序
     std::sort(handleMultiBtnVector.begin(), handleMultiBtnVector.end(), [](MappingRelation a, MappingRelation b) {
         if (a.dev_btn_bit_value == BIGKEY_ZERO || b.dev_btn_bit_value == BIGKEY_ZERO) {
             return false;  // 将空的排在末尾

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -55,7 +55,7 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
                     mapping->dev_btn_bit_value.setBit(index, true); // 设置按键值
                     qDebug("%d, ", index);
                 }
-                qDebug("设置为:0x%s", mapping->dev_btn_bit_value.toString().data());
+                qDebug("设置为:0x%s", mapping->dev_btn_bit_value);
             }
         }
 
@@ -65,7 +65,6 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
         if (mapping->dev_btn_bit_value != BIGKEY_ZERO) {
             MappingRelation newMapping = *mapping;
             handleMultiBtnVector.push_back(newMapping);
-            // qDebug("添加按键映射到handleMultiBtnVector: %s, 0x%s,  %d", mapping->dev_btn_name.data(), mapping->dev_btn_bit_value.toString().data(), mapping->keyboard_value);
         }  
     }
 

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -1,4 +1,5 @@
 #include <simulate_task.h>
+#include "AssistFuncWindow.h"
 #include <global.h>
 #include <QDebug>
 #include<QTimer>
@@ -66,20 +67,22 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
         }
     }
 
-    // 多按键优先级高, 先处理多按键映射,故排序
-    std::sort(handleMultiBtnVector.begin(), handleMultiBtnVector.end(), [](MappingRelation a, MappingRelation b) {
-        if (a.dev_btn_bit_value == BIGKEY_ZERO || b.dev_btn_bit_value == BIGKEY_ZERO) {
-            return false;  // 将空的排在末尾
-        }
-        // 比较加号的数量
-        int aPlusCount = std::count(a.dev_btn_name.begin(), a.dev_btn_name.end(), '+');
-        int bPlusCount = std::count(b.dev_btn_name.begin(), b.dev_btn_name.end(), '+');
-        if (aPlusCount != bPlusCount) {
-            return aPlusCount > bPlusCount;  // 按加号数量降序排列
-        }
-        // 如果加号数量相同, 则字符串大小比较
-        return a.dev_btn_name > b.dev_btn_name;
-    });
+    // 组合键按下时只执行组合键映射，映射多按键优先级高, 故排序先处理多按键映射；当还执行子键映射时，就按配置文件的顺序
+    if (AssistFuncWindow::getEnableOnlyLongestMapping()) {
+        std::sort(handleMultiBtnVector.begin(), handleMultiBtnVector.end(), [](MappingRelation a, MappingRelation b) {
+            if (a.dev_btn_bit_value == BIGKEY_ZERO || b.dev_btn_bit_value == BIGKEY_ZERO) {
+                return false;  // 将空的排在末尾
+            }
+            // 比较加号的数量
+            int aPlusCount = std::count(a.dev_btn_name.begin(), a.dev_btn_name.end(), '+');
+            int bPlusCount = std::count(b.dev_btn_name.begin(), b.dev_btn_name.end(), '+');
+            if (aPlusCount != bPlusCount) {
+                return aPlusCount > bPlusCount;  // 按加号数量降序排列
+            }
+            // 如果加号数量相同, 则字符串大小比较
+            return a.dev_btn_name > b.dev_btn_name;
+        });
+    }
 }
 
 void SimulateTask::closeDevice(){

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -48,14 +48,14 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
         if (mapping->dev_btn_bit_value == BIGKEY_ZERO) {
             std::string btn_name = mapping->dev_btn_name;
             if (btn_name.find("按键") != std::string::npos) {
-                qDebug("%s 按键值为0, 索引: ", btn_name.data());
+                QString debugStr =  QString(btn_name.data()) + ", 索引: ";
                 QStringList btnStrList = QString::fromStdString(btn_name).split("+");
                 for (const QString& btn : btnStrList) {
                     int index = btn.mid(2).toInt(); // 获取按键索引
                     mapping->dev_btn_bit_value.setBit(index, true); // 设置按键值
-                    qDebug("%d, ", index);
+                    debugStr += QString::number(index) + " ";
                 }
-                qDebug("设置为:0x%s", mapping->dev_btn_bit_value);
+                qDebug().noquote().nospace() << debugStr << ", 设置为:" << mapping->dev_btn_bit_value;
             }
         }
 

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -45,18 +45,16 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
 
     for(MappingRelation* mapping : *mappingList){
         // 根据按键名称设置按键值，不从文件中获取
-        if (mapping->dev_btn_bit_value == BIGKEY_ZERO) {
-            std::string btn_name = mapping->dev_btn_name;
-            if (btn_name.find("按键") != std::string::npos) {
-                QString debugStr =  QString(btn_name.data()) + ", 索引: ";
-                QStringList btnStrList = QString::fromStdString(btn_name).split("+");
-                for (const QString& btn : btnStrList) {
-                    int index = btn.mid(2).toInt(); // 获取按键索引
-                    mapping->dev_btn_bit_value.setBit(index, true); // 设置按键值
-                    debugStr += QString::number(index) + " ";
-                }
-                qDebug().noquote().nospace() << debugStr << ", 设置为:" << mapping->dev_btn_bit_value;
+        std::string btn_name = mapping->dev_btn_name;
+        if (btn_name.find("按键") != std::string::npos) {
+            QString debugStr =  QString(btn_name.data()) + ", 索引: ";
+            QStringList btnStrList = QString::fromStdString(btn_name).split("+");
+            for (const QString& btn : btnStrList) {
+                int index = btn.mid(2).toInt(); // 获取按键索引
+                mapping->dev_btn_bit_value.setBit(index, true); // 设置按键值
+                debugStr += QString::number(index) + " ";
             }
+            qDebug().noquote().nospace() << debugStr << ", 设置为:" << mapping->dev_btn_bit_value;
         }
 
         if(isMappingValid(mapping)){

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -44,7 +44,7 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
     this->mappingList = mappingList;
 
     for(MappingRelation* mapping : *mappingList){
-        // 兼容性处理, 如果没有设置按键值, 则根据按键名称设置按键值
+        // 根据按键名称设置按键值，不从文件中获取
         if (mapping->dev_btn_bit_value == BIGKEY_ZERO) {
             std::string btn_name = mapping->dev_btn_name;
             if (btn_name.find("按键") != std::string::npos) {
@@ -65,7 +65,7 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
         if (mapping->dev_btn_bit_value != BIGKEY_ZERO) {
             MappingRelation newMapping = *mapping;
             handleMultiBtnVector.push_back(newMapping);
-        }  
+        }
     }
 
     // 多按键优先级高, 先处理多按键映射,故排序

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -44,6 +44,10 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
     this->mappingList = mappingList;
 
     for(MappingRelation* mapping : *mappingList){
+        if(isMappingValid(mapping)){
+            addMappingToHandleMap(mapping);
+        }
+
         // 根据按键名称设置按键值，不从文件中获取
         std::string btn_name = mapping->dev_btn_name;
         if (btn_name.find("按键") != std::string::npos) {
@@ -55,12 +59,8 @@ SimulateTask::SimulateTask(std::vector<MappingRelation*> *mappingList){
                 debugStr += QString::number(index) + " ";
             }
             qDebug().noquote().nospace() << debugStr << ", 设置为:" << mapping->dev_btn_bit_value;
-        }
 
-        if(isMappingValid(mapping)){
-            addMappingToHandleMap(mapping);
-        }
-        if (mapping->dev_btn_bit_value != BIGKEY_ZERO) {
+            // 将映射添加进多按键映射列表
             MappingRelation newMapping = *mapping;
             handleMultiBtnVector.push_back(newMapping);
         }


### PR DESCRIPTION
本分支增加组合按键映射优先映射且只映射最长组合键的可配置选项。
引进了基于 uint64_t数组（__uint128_t只支持4则运算，故使用成熟的uint64_t） 保存键值的 BigKey类，支持原生位运算。

![image](https://github.com/user-attachments/assets/9fa478b7-96b0-4008-abf2-7612a2d2a9b8)
