### PR TITLE
添加混合映射支持 & 修复主分支不映射转向轴BUG

### DIFF
--- a/global.cpp
+++ b/global.cpp
@@ -11,7 +11,7 @@
 QWidget* g_mainWindow = nullptr;
 
 bool isRuning = false;
-bool isXboxMode = false;
+MappingType defaultMappingType = MappingType::Keyboard;
 LPDIRECTINPUT8 g_pDirectInput = nullptr;
 QList<LPDIRECTINPUTDEVICE8> initedDeviceList; // 已初始化的设备列表
 QList<DiDeviceInfo> diDeviceList;
@@ -125,12 +125,12 @@ bool getIsRunning(){
     return isRuning;
 }
 
-void setIsXboxMode(bool val){
-    isXboxMode = val;
+void setDefaultMappingType(MappingType val){
+    defaultMappingType = val;
 }
 
-bool getIsXboxMode(){
-    return isXboxMode;
+MappingType getDefaultMappingType(){
+    return defaultMappingType;
 }
 
 std::string guidToString(const GUID& guid)
@@ -477,7 +477,7 @@ QList<MappingRelation*> getInputState(bool enableLog, std::vector<MappingRelatio
 
 
             // 映射xbox
-            //if(getIsXboxMode()){
+            // if(getDefaultMappingType() == MappingType::Xbox){
             if(true){
                 if(js.lX == js.lY && js.lY == js.lRx && js.lZ == js.lRx && js.lRx == js.lRy && js.lRy == js.lRz){
                     return list;

--- a/global.h
+++ b/global.h
@@ -16,8 +16,8 @@ extern QWidget* g_mainWindow;
 // 全局映射是否开启
 extern bool isRuning;
 
-// 当前运行模式, true为模拟xbox手柄, false为模拟键盘
-extern bool isXboxMode;
+// 当前默认的映射类型
+extern MappingType defaultMappingType;
 
 // 是否暂停全局映射
 extern bool isPause;
@@ -91,9 +91,9 @@ void setIsRuning(bool val);
 
 bool getIsRunning();
 
-void setIsXboxMode(bool val);
+void setDefaultMappingType(MappingType val);
 
-bool getIsXboxMode();
+MappingType getDefaultMappingType();
 
 extern double xboxJoystickInnerDeadAreaValue;
 extern double xboxTriggerInnerDeadAreaValue;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -293,7 +293,7 @@ void MainWindow::on_pushButton_2_clicked()
         }
 
         // xbox模式, 但驱动未安装, 无法启动
-        // if(getIsXboxMode() && !checkDriverInstalled()){
+        // if(getDefaultMappingType() == MappingType::Xbox && !checkDriverInstalled()){
         if(!checkDriverInstalled()){
             qDebug("驱动未安装, 无法启动!");
             return;
@@ -897,7 +897,7 @@ void MainWindow::loadLastDeviceFile(){
                 if(in.readLine().toStdString() == XBOX){
                     ui->radioButton_2->setChecked(true);
                     //ui->label_7->setText("Xbox按键");
-                    setIsXboxMode(true);
+                    setDefaultMappingType(MappingType::Xbox);
                 }
             }
 
@@ -1126,7 +1126,7 @@ MappingRelation* MainWindow::getDevBtnData(){
                         // 不是第一次读到该轴的值, 与第一次的值比较, 大于一定量才能确定是该轴要新建映射
                         if(std::abs(item->dev_btn_value - tmpAxis->second) > AXIS_CHANGE_VALUE){
                             // 映射xbox模式
-                            if(getIsXboxMode()){
+                            if(getDefaultMappingType() == MappingType::Xbox){
                                 return item;
                             }else{
                                 // 映射键盘模式
@@ -1506,14 +1506,14 @@ bool MainWindow::checkDriverInstalled() {
 
 void MainWindow::on_radioButton_clicked()
 {
-    if(!getIsXboxMode()){
+    if(getDefaultMappingType() == MappingType::Keyboard){
         return;
     }
 
     //ui->label_7->setText("键盘按键");
 
     // 设置为键盘模式
-    setIsXboxMode(false);
+    setDefaultMappingType(MappingType::Keyboard);
 
     // 重置配置文件下拉
     ui->comboBox_2->clear();
@@ -1529,7 +1529,7 @@ void MainWindow::on_radioButton_clicked()
 
 void MainWindow::on_radioButton_2_clicked()
 {
-    if(getIsXboxMode()){
+    if(getDefaultMappingType() == MappingType::Xbox){
         return;
     }
 
@@ -1539,7 +1539,7 @@ void MainWindow::on_radioButton_2_clicked()
     checkDriverInstalled();
 
     // 设置为xbox模式
-    setIsXboxMode(true);
+    setDefaultMappingType(MappingType::Xbox);
 
     // 重置配置文件下拉
     ui->comboBox_2->clear();
@@ -1612,7 +1612,7 @@ void MainWindow::simulateStartedSlot(){
 void MainWindow::on_pushButton_8_clicked()
 {
     // 如果是映射xbox模式, 打开xbox死区设置窗口
-    if(getIsXboxMode()){
+    if(getDefaultMappingType() == MappingType::Xbox){
         // 如果窗口是最小化状态, 清除最小化
         if(this->xboxDeadareaSettings->windowState() == Qt::WindowMinimized){
             this->xboxDeadareaSettings->setWindowState(this->xboxDeadareaSettings->windowState() & ~Qt::WindowMinimized);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -433,7 +433,11 @@ void MainWindow::paintOneLineMapping(MappingRelation *mapping, int index){
         mapping = getDevBtnData();
 
         // 根据用户配置的默认映射方式配置
-        mapping->setMappingType(getIsXboxMode() ? MappingType::Xbox : MappingType::Keyboard);
+        if (ui->radioButton->isChecked()) {
+            mapping->setMappingType(MappingType::Keyboard);
+        } else if (ui->radioButton_2->isChecked()) {
+            mapping->setMappingType(MappingType::Xbox);
+        } 
 
         if(mapping == nullptr){
             showErrorMessage(new std::string("未检测到按键被按下!"));
@@ -528,7 +532,11 @@ void MainWindow::paintOneLineMapping(MappingRelation *mapping, int index){
     btn->setObjectName(currentRowIndex);
     // 绑定信号和槽
     connect(btn, &QPushButton::clicked, this, [=](){
-        mapping->setMappingType(mapping->mappingType == MappingType::Xbox ? MappingType::Keyboard : MappingType::Xbox);
+        if (mapping->mappingType == MappingType::Keyboard){
+            mapping->setMappingType(MappingType::Xbox);
+        }else if (mapping->mappingType == MappingType::Xbox){
+            mapping->setMappingType(MappingType::Keyboard);
+        }
         updateASwitchPushButton(btn, mapping->mappingType);
         updateAKeyBoardComboBox(comboBox, mapping->dev_btn_type, mapping->mappingType);
     });
@@ -710,7 +718,7 @@ void MainWindow::saveMappingsToFile(std::string filename){
             text.append("\"remark\":\"" + item->remark + "\"").append(", ");
             text.append("\"rotateAxis\":" + std::to_string(item->rotateAxis)).append(", ");
             text.append("\"btnTriggerType\":" + std::to_string(item->btnTriggerType)).append(", ");
-            text.append("\"mappingType\":" + QString::number(item->mappingType == MappingType::Xbox ? 1 : 0)).append(", ");
+            text.append("\"mappingType\":" + QString::number((int)item->mappingType)).append(", ");
             text.append("\"deviceName\":\"" + item->deviceName + "\"");// 最后一个, 后面不用加逗号
           
             text.append("},\n\t");
@@ -975,7 +983,14 @@ void MainWindow::loadMappingsFile(std::string filename){
                 } else if (mappingFileNameMap[filename.data()].endsWith(MAPPING_FILE_SUFFIX)) {
                     mapping->mappingType = MappingType::Keyboard;
                 } else {
-                    mapping->mappingType = ((MappingType)(jsonObj.contains("mappingType") && jsonObj["mappingType"].toInt()) == MappingType::Xbox) ? MappingType::Xbox : MappingType::Keyboard;
+                    if (jsonObj.contains("mappingType")) {
+                        // 读取映射类型
+                        if ((MappingType)jsonObj["mappingType"].toInt() == MappingType::Xbox) {
+                            mapping->mappingType = MappingType::Xbox;
+                        } else if ((MappingType)jsonObj["mappingType"].toInt() == MappingType::Keyboard) {
+                            mapping->mappingType = MappingType::Keyboard;
+                        }
+                    } 
                 }
                 mapping->deviceName = (jsonObj.contains("deviceName") ? jsonObj["deviceName"].toString() : "");
 
@@ -1199,13 +1214,13 @@ std::map<std::string, short> MainWindow::getConstKeyMap(std::string dev_btn_type
 }
 
 void MainWindow::updateASwitchPushButton(QPushButton *btn, MappingType mappingType){
-        if(mappingType == MappingType::Keyboard){
-            btn->setText("> 键盘 <");
-            btn->setStyleSheet("QPushButton{background-color:rgb(170, 255, 255);margin-left:7;color: black;}");
-        }else if (mappingType == MappingType::Xbox){
-            btn->setText("> Xbox <");
-            btn->setStyleSheet("QPushButton{background-color:rgb(255, 170, 127);margin-left:7;color: black;}");
-        }
+    if(mappingType == MappingType::Keyboard){
+        btn->setText("> 键盘 <");
+        btn->setStyleSheet("QPushButton{background-color:rgb(170, 255, 255);margin-left:7;color: black;}");
+    }else if (mappingType == MappingType::Xbox){
+        btn->setText("> Xbox <");
+        btn->setStyleSheet("QPushButton{background-color:rgb(255, 170, 127);margin-left:7;color: black;}");
+    }
 }
     
 void MainWindow::updateAKeyBoardComboBox(QComboBox *comboBox, std::string dev_btn_type, MappingType mappingType){

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -540,6 +540,9 @@ void MainWindow::paintOneLineMapping(MappingRelation *mapping, int index){
         }
         updateASwitchPushButton(btn, mapping->mappingType);
         updateAKeyBoardComboBox(comboBox, mapping->dev_btn_type, mapping->mappingType);
+        /* ## 还需要处理 轴映射
+         * 待处理
+         */
     });
 
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -545,7 +545,8 @@ void MainWindow::paintOneLineMapping(MappingRelation *mapping, int index){
             }
             updateASwitchPushButton(btn, mapping->mappingType);
             updateAKeyBoardComboBox(comboBox, mapping->dev_btn_type, mapping->mappingType);
-
+            mapping->keyboard_name = comboBox->currentText().toStdString();
+            mapping->keyboard_value = 0;
         });
         btn->setEnabled(true);
     } else {
@@ -1254,6 +1255,7 @@ void MainWindow::updateAKeyBoardComboBox(QComboBox *comboBox, std::string dev_bt
         }
         comboBox->addItem(item->first.data());
     }
+    comboBox->setCurrentIndex(-1);
 }
 
 // 创建一个键盘按键下拉选择框

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -293,7 +293,8 @@ void MainWindow::on_pushButton_2_clicked()
         }
 
         // xbox模式, 但驱动未安装, 无法启动
-        if(getIsXboxMode() && !checkDriverInstalled()){
+        // if(getIsXboxMode() && !checkDriverInstalled()){
+        if(!checkDriverInstalled()){
             qDebug("驱动未安装, 无法启动!");
             return;
         }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -25,6 +25,7 @@
 #define USER_MAPPINGS_DIR "userMappings/"
 #define MAPPING_FILE_SUFFIX ".di_mappings_config"
 #define MAPPING_FILE_SUFFIX_XBOX ".di_xbox_mappings_config"
+#define MAPPING_FILE_SUFFIX_MIXED ".di_mixed_mappings_config"
 #define KEYBOARD "keyboard"
 #define XBOX "xbox"
 #define AXIS_CHANGE_VALUE 2000 //识别轴需要变化的最小值

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QLabel>
+#include <QPushButton>
 #include <windows.h>
 #include <cstring>
 #include <QVBoxLayout>
@@ -77,14 +78,16 @@ protected:
 
     MappingRelation* getDevBtnData();
 
-    std::map<std::string, short> getConstKeyMap(std::string dev_btn_type);
+    std::map<std::string, short> getConstKeyMap(std::string dev_btn_type, MappingType mappingType);
 
     void scanMappingFile();
 
     // 上一次使用的设备是否在当前设备列表
     bool hasLastDevInCurrentDeviceList(std::string lastDeviceName);
 
-    QComboBox* createAKeyBoardComboBox(std::string dev_btn_type);
+    QComboBox* createAKeyBoardComboBox(std::string dev_btn_type, MappingType mappingType);
+    void updateAKeyBoardComboBox(QComboBox* comboBox, std::string dev_btn_type, MappingType mappingType);
+    void updateASwitchPushButton(QPushButton* btn, MappingType mappingType);
 
     void showErrorMessage(std::string *text);
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -277,27 +277,27 @@ QComboBox QAbstractItemView {
    <widget class="QRadioButton" name="radioButton">
     <property name="geometry">
      <rect>
-      <x>20</x>
+      <x>90</x>
       <y>80</y>
       <width>91</width>
       <height>23</height>
      </rect>
     </property>
     <property name="text">
-     <string>映射键盘</string>
+     <string>键盘</string>
     </property>
    </widget>
    <widget class="QRadioButton" name="radioButton_2">
     <property name="geometry">
      <rect>
-      <x>120</x>
+      <x>150</x>
       <y>80</y>
       <width>121</width>
       <height>23</height>
      </rect>
     </property>
     <property name="text">
-     <string>映射Xbox手柄</string>
+     <string>Xbox手柄</string>
     </property>
    </widget>
    <widget class="QPushButton" name="pushButton_6">
@@ -411,6 +411,19 @@ QComboBox QAbstractItemView {
     </property>
     <property name="text">
      <string>清空已选择设备</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_6">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>80</y>
+      <width>53</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>默认映射：</string>
     </property>
    </widget>
   </widget>

--- a/mapping_relation.h
+++ b/mapping_relation.h
@@ -6,6 +6,11 @@
 //using namespace std;
 #define BUTTONS_VALUE_TYPE BigKey
 
+enum class MappingType{
+    Keyboard,
+    Xbox,
+};
+
 class MappingRelation{
 public:
     int dev_btn_pos; // 设备按键位置
@@ -19,6 +24,7 @@ public:
     int rotateAxis = 0; // 是否反转轴, 0不反转, 1反转
     TriggerTypeEnum btnTriggerType = TriggerTypeEnum::Normal; // 按键触发类型, 默认同步模式
     QString deviceName = "";// 当前映射所属设备名称
+    MappingType mappingType = MappingType::Keyboard; // 映射类型, 默认键盘映射
 
     MappingRelation(){}
     MappingRelation(int dev_btn_pos, int dev_btn_value, short keyboard_value, std::string keyboard_name){
@@ -68,6 +74,10 @@ public:
 
     void setDeviceName(QString deviceName){
         this->deviceName = deviceName;
+    }
+
+    void setMappingType(MappingType mappingType){
+        this->mappingType = mappingType;
     }
 };
 

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -14,7 +14,11 @@ void SimulateTask::addMappingToHandleMap(MappingRelation* mapping){
     if(mapping != nullptr){
         std::string btnStr = mapping->deviceName.toStdString() + "-" + mapping->dev_btn_name;
 
+        // 记录按键触发模式
         keyTriggerTypeMap.insert_or_assign(btnStr, mapping->btnTriggerType);
+
+        // 记录按键映射类型
+        keyMappingTypeMap.insert_or_assign(btnStr, mapping->mappingType);
 
         // 记录需要反转的轴
         if(mapping->rotateAxis == 1){
@@ -132,7 +136,7 @@ void SimulateTask::releaseAllKey(QList<MappingRelation*> pressBtnList){
         if (pressBtnList.empty() || !isCurrentBtnInList(pressBtnList, btnStr)) {
             //qDebug("按键释放");
             // 映射键盘
-            if(!getIsXboxMode()){
+            if(keyMappingTypeMap[btnStr] == MappingType::Keyboard){
                 // 根据触发模式, 进行对应处理
                 switch (keyTriggerTypeMap[btnStr]) {
                 case TriggerTypeEnum::Release:
@@ -404,6 +408,8 @@ QList<MappingRelation*> SimulateTask::handleResult(QList<MappingRelation*> res){
         for(auto &currentBtn : res){
             auto btnStr = currentBtn->dev_btn_name;
             // 轴映射键盘
+            // std::string btnStr2 = currentBtn->deviceName.toStdString() + "-" + btnStr;
+            // if((keyMappingTypeMap[btnStr2] == MappingType::Keyboard) && btnStr.find("轴") != std::string::npos){
             if(!getIsXboxMode() && btnStr.find("轴") != std::string::npos){
                 // 当前轴的值范围
                 auto currentRange = axisValueRangeMap.find(btnStr)->second;
@@ -471,16 +477,16 @@ void SimulateTask::doWork(){
     qDebug("全局映射启动!");
 
     // 模拟xbox手柄, 需要初始化
-    if(getIsXboxMode()){
-        if(!initXboxController()){
-            // 关闭虚拟xbox设备
-            closeXboxController();
+    // if(getIsXboxMode()){
+    if(!initXboxController()){
+        // 关闭虚拟xbox设备
+        closeXboxController();
 
-            // 提交工作结束信号
-            emit workFinished();
-            return;
-        }
+        // 提交工作结束信号
+        emit workFinished();
+        return;
     }
+    // }
 
     setIsRuning(true);
     emit startedSignal();
@@ -541,7 +547,7 @@ void SimulateTask::doWork(){
                 }
 
                 // 映射键盘
-                if(!getIsXboxMode()){
+                if(keyMappingTypeMap[btnStr] == MappingType::Keyboard){
                     // 对映射鼠标左键(-7), 鼠标右键(-8), 鼠标中键(-11), 以及其它键盘按键进行按下记录
                     if(item->second == -7 || item->second == -8 || item->second == -11 ||  item->second > 0){
                         // 记录按键按下

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -406,11 +406,9 @@ QList<std::string> SimulateTask::getBtnStrListFromHandleMap(std::string btnStr){
 QList<MappingRelation*> SimulateTask::handleResult(QList<MappingRelation*> res){
     if(!res.isEmpty()){
         for(auto &currentBtn : res){
-            auto btnStr = currentBtn->dev_btn_name;
+            auto btnStr = currentBtn->deviceName.toStdString() + "-" + currentBtn->dev_btn_name;
             // 轴映射键盘
-            // std::string btnStr2 = currentBtn->deviceName.toStdString() + "-" + btnStr;
-            // if((keyMappingTypeMap[btnStr2] == MappingType::Keyboard) && btnStr.find("轴") != std::string::npos){
-            if(getDefaultMappingType() == MappingType::Keyboard && btnStr.find("轴") != std::string::npos){
+            if((keyMappingTypeMap[btnStr] == MappingType::Keyboard) && btnStr.find("轴") != std::string::npos){
                 // 当前轴的值范围
                 auto currentRange = axisValueRangeMap.find(btnStr)->second;
                 int currentMin = currentRange.lMin, currentMax = currentRange.lMax;

--- a/simulate_task.cpp
+++ b/simulate_task.cpp
@@ -410,7 +410,7 @@ QList<MappingRelation*> SimulateTask::handleResult(QList<MappingRelation*> res){
             // 轴映射键盘
             // std::string btnStr2 = currentBtn->deviceName.toStdString() + "-" + btnStr;
             // if((keyMappingTypeMap[btnStr2] == MappingType::Keyboard) && btnStr.find("轴") != std::string::npos){
-            if(!getIsXboxMode() && btnStr.find("轴") != std::string::npos){
+            if(getDefaultMappingType() == MappingType::Keyboard && btnStr.find("轴") != std::string::npos){
                 // 当前轴的值范围
                 auto currentRange = axisValueRangeMap.find(btnStr)->second;
                 int currentMin = currentRange.lMin, currentMax = currentRange.lMax;
@@ -477,7 +477,7 @@ void SimulateTask::doWork(){
     qDebug("全局映射启动!");
 
     // 模拟xbox手柄, 需要初始化
-    // if(getIsXboxMode()){
+    // if(getDefaultMappingType() == MappingType::Xbox){
     if(!initXboxController()){
         // 关闭虚拟xbox设备
         closeXboxController();

--- a/simulate_task.h
+++ b/simulate_task.h
@@ -30,14 +30,16 @@ class SimulateTask : public QObject {
 private:
     //hid_device *handle;// 当前设备的连接句柄
     std::vector<MappingRelation*> *mappingList;// 已配置的按键映射列表
-    std::map<std::string, short> handleMap;// 设备按键对应键盘扫描码map
+    std::map<std::string, short> handleMap;// 设备按键对应键盘扫描码map; key: 设备-按键名称, value: 键盘扫描码
     static std::vector<MappingRelation> handleMultiBtnVector;// 当前在使用的 设备组合键映射列表
     static std::vector<MappingRelation> handleMultiBtnVectorUnsort;// 未排序的 设备组合键映射列表
     static std::vector<MappingRelation> handleMultiBtnVectorSorted;// 已排序的 设备组合键映射列表(根据组合键的子键数量倒序)
 
-    std::map<std::string, short> keyHoldingMap;// 记录按键一直按着的map
+    std::map<std::string, short> keyHoldingMap;// 记录按键一直按着的map; key: 设备-按键名称, value: 键盘扫描码
 
-    std::map<std::string, TriggerTypeEnum> keyTriggerTypeMap;// 记录按键触发模式的map
+    std::map<std::string, TriggerTypeEnum> keyTriggerTypeMap;// 记录按键触发模式的map; key: 设备-按键名称, value: 键盘扫描码
+
+    std::map<std::string, MappingType> keyMappingTypeMap;// 记录按键映射类型的map; key: 设备-按键名称, value: 键盘扫描码
 
     //std::map<int, short> keyPosMap;// 记录按键位置对应键盘扫描码map
 


### PR DESCRIPTION
Hello啊，这个PR主要是解决打开一个软件就能同时支持`DIY拨杆`映射键盘和`方向盘`映射Xbox。

已开发：
- 添加混合映射支持
- 修复主分支不映射转向轴BUG（左转/右转映射失效，见 commit id： e90e9b7fb4742237eb9e62b6ba326fb8aec6ec04 ）
-  ~~引入新BUG~~

似乎没发现其他BUG了，后续可以优化的地方：
- 转向轴映射, 暂不支持混合映射切换（ 56a775e3fb63b62a647065d45311effebdfe1f93 ）
- 旧文件可能会与新文件同名，同名文件处理逻辑可以优化一下，或者保存文件时不允许同名（ e5730c74246aab21a4b10c19a582b4ff137a29bb ）
- 两个死区设置弹窗可以合并

![image](https://github.com/user-attachments/assets/b15c61a5-c18d-4dd8-a7d9-d1847e8589c7)