### PR TITLE
更新 欧卡2/美卡 原生绑定向导组件

### DIFF
--- a/ETS2_KeyBinder/ets2keybinderwizard.cpp
+++ b/ETS2_KeyBinder/ets2keybinderwizard.cpp
@@ -544,7 +544,7 @@ bool ETS2KeyBinderWizard::generateMappingFile(ActionEffect hblight, ActionEffect
     return true;
 }
 
-bool ETS2KeyBinderWizard::checkHardwareDeviceAndMsgBox() {
+bool ETS2KeyBinderWizard::checkHardwareDeviceAndMsgBox(BindingType bindingType) {
     if (deviceName.empty() || isDeviceReady == false) {
         QMessageBox box(QMessageBox::Warning, "设备连接异常",
                         "请返回第3步，将设备连接到电脑，\n在“硬件控制设备”下拉框选择设备\n" + MEG_BOX_LINE + "\n或者进行手动绑定？");
@@ -552,7 +552,7 @@ bool ETS2KeyBinderWizard::checkHardwareDeviceAndMsgBox() {
         box.setDefaultButton(QMessageBox::Ok);
         box.exec();
         if (box.clickedButton() == box.button(QMessageBox::Ok)) {
-            on_pushButton_16_clicked();
+            showManuallyBinder(bindingType);
         } else {
             // 返回第三步(不使用setCurrentId()跳转)
             this->restart();
@@ -565,7 +565,7 @@ bool ETS2KeyBinderWizard::checkHardwareDeviceAndMsgBox() {
 }
 
 void ETS2KeyBinderWizard::oneKeyBind(BindingType bindingType, const QString& message) {
-    if (checkHardwareDeviceAndMsgBox() == false) {
+    if (checkHardwareDeviceAndMsgBox(bindingType) == false) {
         return; // 设备未连接，取消操作
     }
 
@@ -633,6 +633,8 @@ void ETS2KeyBinderWizard::multiKeyBind(std::map<BindingType, ActionEffect> actio
 
 std::vector<BigKey> ETS2KeyBinderWizard::getMultiKeyState(const QString& title, const QStringList& messages) {
     if (checkHardwareDeviceAndMsgBox() == false) {
+        ui->checkBox_3->setChecked(true); 
+        on_checkBox_3_clicked(true);
         return {}; // 设备未连接，取消操作
     }
 
@@ -975,18 +977,23 @@ void ETS2KeyBinderWizard::on_checkBox_3_clicked(bool checked) {
     ui->stackedWidget->setCurrentIndex(checked);
 }
 
-// 手动绑定
-void ETS2KeyBinderWizard::on_pushButton_16_clicked() {
+void ETS2KeyBinderWizard::showManuallyBinder(BindingType bindingType) {
     ManuallyBinder* manuallyBinder = new ManuallyBinder(this);
     manuallyBinder->setAttribute(Qt::WA_DeleteOnClose); // 关闭时自动删除
     // 当manuallyBinder没关闭时，不允许操作其他窗口
     manuallyBinder->setWindowModality(Qt::ApplicationModal); // 设置窗口模式为应用程序模态
 
     manuallyBinder->setKeyCount(128); // 设置按键数量
+    manuallyBinder->setBindingType(bindingType); // 设置绑定类型
 
     // 连接信号槽
     connect(manuallyBinder, &ManuallyBinder::keyBound, this, &ETS2KeyBinderWizard::modifyControlsSii_Slot, Qt::DirectConnection);
     manuallyBinder->show();
+}
+
+// 手动绑定
+void ETS2KeyBinderWizard::on_pushButton_16_clicked() {
+    showManuallyBinder(BindingType::lightpark);
 }
 
 void ETS2KeyBinderWizard::modifyControlsSii_Slot(BindingType bindingType, ActionEffect actionEffect) {

--- a/ETS2_KeyBinder/ets2keybinderwizard.cpp
+++ b/ETS2_KeyBinder/ets2keybinderwizard.cpp
@@ -633,7 +633,7 @@ void ETS2KeyBinderWizard::multiKeyBind(std::map<BindingType, ActionEffect> actio
 
 std::vector<BigKey> ETS2KeyBinderWizard::getMultiKeyState(const QString& title, const QStringList& messages) {
     if (checkHardwareDeviceAndMsgBox() == false) {
-        ui->checkBox_3->setChecked(true); 
+        ui->checkBox_3->setChecked(true);
         on_checkBox_3_clicked(true);
         return {}; // 设备未连接，取消操作
     }
@@ -983,7 +983,7 @@ void ETS2KeyBinderWizard::showManuallyBinder(BindingType bindingType) {
     // 当manuallyBinder没关闭时，不允许操作其他窗口
     manuallyBinder->setWindowModality(Qt::ApplicationModal); // 设置窗口模式为应用程序模态
 
-    manuallyBinder->setKeyCount(128); // 设置按键数量
+    manuallyBinder->setKeyCount(128);            // 设置按键数量
     manuallyBinder->setBindingType(bindingType); // 设置绑定类型
 
     // 连接信号槽
@@ -1002,15 +1002,7 @@ void ETS2KeyBinderWizard::modifyControlsSii_Slot(BindingType bindingType, Action
         return;
     }
 
-    QString ets2BtnStr;
-    for (const auto& action : actionEffect) {
-        int keyIndex = action.first; // 获取按键索引
-        if (action.second == false) {
-            ets2BtnStr += "!";
-        }
-        ets2BtnStr += gameJoyPosNameList[ui->comboBox_2->currentIndex()].trimmed() + ".b" + QString::number(keyIndex + 1) + " & "; // 1基索引
-    }
-    ets2BtnStr.chop(3); // 去掉最后的 " & "
+    QString ets2BtnStr = convertToETS2_String(gameJoyPosNameList[ui->comboBox_2->currentIndex()], actionEffect); // 1基索引
 
     qDebug() << "修改的按键:" << ets2BtnStr;
     backupProfile(); // 备份配置文件

--- a/ETS2_KeyBinder/ets2keybinderwizard.cpp
+++ b/ETS2_KeyBinder/ets2keybinderwizard.cpp
@@ -48,9 +48,8 @@ ETS2KeyBinderWizard::ETS2KeyBinderWizard(QWidget* parent) : QWizard(parent), ui(
             updateUserProfile();                                      // 更新用户配置文件
             QStringList gameJoyPosNameList = getDeviceNameGameList(); // 获取游戏配置文件中的设备名称列表
 
-            if(gameJoyPosNameList.isEmpty()){
-                // 禁止点击下一步
-                this->button(QWizard::NextButton)->setEnabled(false);
+            if (gameJoyPosNameList.isEmpty()) {
+                return;
             }
 
             // 更新到下拉框
@@ -159,24 +158,24 @@ QStringList ETS2KeyBinderWizard::getDeviceNameGameList() {
     } else {
         globalControlsFilePath = QDir::homePath() + "/Documents/American Truck Simulator/global_controls.sii";
     }
+
     QFile file(globalControlsFilePath);
-    QString errorMsg = "\n\n全局配置文件路径:\n" + globalControlsFilePath + "\n\n请返回第一步，确定已禁用Steam输入";
-
-    if(!file.exists()){
-        QMessageBox::critical(this, "错误", "游戏全局配置文件不存在!" + errorMsg);
-        setCurrentId(0);
+    QString errorMsg = "\n\n文件路径：\n" + globalControlsFilePath + "\n\n请返回第一步，确定已禁用Steam输入";
+    if (!file.exists()) {
+        qDebug() << "全局配置文件不存在：" << file.fileName();
+        QMessageBox::critical(this, "错误", "游戏全局配置文件不存在！" + errorMsg);
+        this->restart(); // 返回第一步
         return QStringList();
     }
-
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qDebug() << "无法打开文件:" << file.fileName();
-        QMessageBox::critical(this, "错误", "打开游戏全局配置文件失败!" + errorMsg);
-        setCurrentId(0);
+        qDebug() << "无法打开文件：" << file.fileName();
+        QMessageBox::critical(this, "错误", "打开游戏全局配置文件失败！" + errorMsg);
+        this->restart(); // 返回第一步
         return QStringList();
     }
-    QTextStream inGlobal(&file);
-    map<QString, QString> deviceNameList;
 
+    QTextStream inGlobal(&file);
+    map<QString, QString> globalDeviceNameList; // 全局配置文件中的设备名称列表
     QRegularExpression regex1(R"(`di8\.'{(.*?)}\|{(.*?)}'`.*?\|(.+)\s*")");
     while (!inGlobal.atEnd()) {
         QString line = inGlobal.readLine();
@@ -186,7 +185,7 @@ QStringList ETS2KeyBinderWizard::getDeviceNameGameList() {
             if (match.hasMatch()) {
                 QString guid = "{" + match.captured(1) + "}|{" + match.captured(2) + "}";
                 QString name = match.captured(3);
-                deviceNameList.insert_or_assign(guid, name);
+                globalDeviceNameList.insert_or_assign(guid, name);
             }
         }
     }
@@ -194,23 +193,19 @@ QStringList ETS2KeyBinderWizard::getDeviceNameGameList() {
 
     // 读取配置文件列表
     QFile profileFile(selectedProfilePath);
-
-    if(!profileFile.exists()){
-        QMessageBox::critical(this, "错误", "游戏配置文件不存在!"
-                                            "\n配置文件参考路径如下:"
-                                            "\n欧卡2: " + QDir::homePath() + "/Documents/Euro Truck Simulator 2/profiles或者steam_profiles/xxxxxx/controls.sii"
-                                            "\n美卡: " + QDir::homePath() + "/Documents/American Truck Simulator/profiles或者steam_profiles/xxxxxx/controls.sii");
+    if (!profileFile.exists()) {
+        QMessageBox::critical(this, "错误", "游戏配置文件不存在！文件路径：\n" + selectedProfilePath);
         return QStringList();
     }
 
     if (!profileFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
         qDebug() << "无法打开文件:" << profileFile.fileName();
-        QMessageBox::critical(this, "错误", "打开游戏配置文件失败!\n配置文件路径:" + selectedProfilePath);
+        QMessageBox::critical(this, "错误", "打开游戏配置文件失败！文件路径：\n" + selectedProfilePath);
         return QStringList();
     }
 
     QTextStream inProfile(&profileFile);
-    QStringList profileList = gameJoyPosNameList;
+    QStringList profilesGameJoyList = gameJoyPosNameList; // 游戏配置文件中的设备名称列表
     QRegularExpression regex2(R"(`di8\.'{(.*?)}\|{(.*?)}'`)");
     while (!inProfile.atEnd()) {
         QString line = inProfile.readLine();
@@ -219,14 +214,14 @@ QStringList ETS2KeyBinderWizard::getDeviceNameGameList() {
                 QRegularExpressionMatch match = regex2.match(line);
                 if (match.hasMatch()) {
                     QString guid = "{" + match.captured(1) + "}|{" + match.captured(2) + "}";
-                    QString name = deviceNameList[guid];
-                    profileList[i] = name + "(" + match.captured(2).left(8) + ")";
+                    QString name = globalDeviceNameList[guid];
+                    profilesGameJoyList[i] = name + "(" + match.captured(2).left(8) + ")";
                 }
             }
         }
     }
     profileFile.close();
-    return profileList;
+    return profilesGameJoyList;
 }
 
 bool ETS2KeyBinderWizard::hasLastDevInCurrentDeviceList(std::string lastDeviceName) {
@@ -242,11 +237,10 @@ bool ETS2KeyBinderWizard::hasLastDevInCurrentDeviceList(std::string lastDeviceNa
 bool ETS2KeyBinderWizard::backupProfile() {
     QFile selectedProfileFile(selectedProfilePath);
     if (!selectedProfileFile.exists()) {
-        qDebug() << "配置文件不存在:" << selectedProfilePath;
-        QMessageBox::critical(this, "错误", "备份配置文件失败: 游戏配置文件不存在!"
-                                            "\n配置文件参考路径如下:"
-                                            "\n欧卡2: " + QDir::homePath() + "/Documents/Euro Truck Simulator 2/profiles或者steam_profiles/xxxxxx/controls.sii"
-                                            "\n美卡: " + QDir::homePath() + "/Documents/American Truck Simulator/profiles或者steam_profiles/xxxxxx/controls.sii");
+        qDebug() << "配置文件不存在：" << selectedProfilePath;
+        QMessageBox::critical(this, "错误",
+                              "备份游戏配置文件失败：该文件不存在！参考路径：\n\n" + steamProfiles[ui->comboBox_4->currentIndex()]
+                                  + "/xxxxxx/controls.sii\n" + profiles[ui->comboBox_4->currentIndex()] + "/xxxxxx/controls.sii\n");
         return false;
     }
 
@@ -278,11 +272,17 @@ void ETS2KeyBinderWizard::modifyControlsSii(const QString& controlsFilePath, Bin
 
     // 检查文件是否存在
     if (!QFileInfo::exists(controlsFilePath)) {
-        QMessageBox::critical(this, "错误", "修改游戏配置文件失败: 游戏配置文件不存在!"
-                                            "\n配置文件参考路径如下:"
-                                            "\n欧卡2: " + QDir::homePath() + "/Documents/Euro Truck Simulator 2/profiles或者steam_profiles/xxxxxx/controls.sii"
-                                            "\n美卡: " + QDir::homePath() + "/Documents/American Truck Simulator/profiles或者steam_profiles/xxxxxx/controls.sii");
-        qWarning() << "文件未找到:" << controlsFilePath;
+        qDebug() << "配置文件不存在：" << controlsFilePath;
+        QMessageBox::critical(this, "错误",
+                              "修改游戏配置文件失败：该文件不存在！参考路径：\n" + steamProfiles[ui->comboBox_4->currentIndex()]
+                                  + "/xxxxxx/controls.sii\n" + profiles[ui->comboBox_4->currentIndex()] + "/xxxxxx/controls.sii\n");
+        return;
+    }
+
+    // 打开文件并读取内容
+    if (!controlsFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qDebug() << "无法打开文件：" << controlsFilePath;
+        QMessageBox::critical(this, "错误", "打开游戏配置文件失败！文件路径：\n" + controlsFilePath);
         return;
     }
 
@@ -314,7 +314,7 @@ void ETS2KeyBinderWizard::modifyControlsSii(const QString& controlsFilePath, Bin
     };
 
     if (replaceRules.find(bindingType) == replaceRules.end()) {
-        qWarning() << "无效的绑定类型";
+        qDebug() << "无效的绑定类型";
         return;
     }
 
@@ -322,22 +322,14 @@ void ETS2KeyBinderWizard::modifyControlsSii(const QString& controlsFilePath, Bin
     QString pattern = replaceRules[bindingType];
     QString replacement = QString("mix %1 `%2 | semantical.%1?0`").arg(bindingTypeString[bindingType], ets2BtnStr);
 
-    // 打开文件并读取内容
-    if (!controlsFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qWarning() << "无法打开文件:" << controlsFilePath;
-        QMessageBox::critical(this, "错误", "打开游戏配置文件失败!\n配置文件路径:\n" + controlsFilePath);
-        return;
-    }
-
     QTextStream in(&controlsFile);
     QStringList lines;
     bool modified = false;
-
     while (!in.atEnd()) {
         QString line = in.readLine();
         QRegularExpression regex(pattern);
         if (line.contains(regex)) {
-            qDebug() << "匹配到:" << line.trimmed();
+            qDebug() << "匹配到：" << line.trimmed();
             line.replace(regex, replacement);
             modified = true;
         }
@@ -348,8 +340,8 @@ void ETS2KeyBinderWizard::modifyControlsSii(const QString& controlsFilePath, Bin
     // 如果有修改，写回文件
     if (modified) {
         if (!controlsFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-            qWarning() << "无法写入文件:" << controlsFilePath;
-            QMessageBox::critical(this, "错误", "写入游戏配置文件失败!\n配置文件路径:\n" + controlsFilePath);
+            qDebug() << "无法写入文件：" << controlsFilePath;
+            QMessageBox::critical(this, "错误", "无法写入游戏配置文件！文件路径：\n" + controlsFilePath);
             return;
         }
 
@@ -358,7 +350,7 @@ void ETS2KeyBinderWizard::modifyControlsSii(const QString& controlsFilePath, Bin
             out << line << "\n";
         }
         controlsFile.close();
-        qDebug() << "成功修改文件:" << controlsFilePath;
+        qDebug() << "成功修改文件：" << controlsFilePath;
     } else {
         qDebug() << "未检测到需要修改的内容";
     }
@@ -378,7 +370,7 @@ QString convertToETS2_String(const QString& gameJoyPosStr, const ActionEffect& a
         ets2BtnStr += gameJoyPosStr.trimmed() + ".b" + QString::number(item.first + 1) + "?0 & ";
     }
     ets2BtnStr.chop(3); // 去掉最后的 &
-    qDebug() << "转换后的 ETS2 按键字符串:" << ets2BtnStr;
+    qDebug() << "转换后的 ETS2 按键字符串：" << ets2BtnStr;
     return ets2BtnStr;
 }
 
@@ -387,7 +379,7 @@ QList<QPair<QString, QDateTime>> listFoldersWithModificationDates(const QDir& di
     QList<QPair<QString, QDateTime>> folderInfo;
 
     if (!directory.exists()) {
-        qWarning() << "路径" << directory.absolutePath() << "不存在!";
+        qDebug() << "路径" << directory.absolutePath() << "不存在！";
         return folderInfo;
     }
 
@@ -413,13 +405,13 @@ void ETS2KeyBinderWizard::updateUserProfile() {
     QList<QPair<QString, QDateTime>> allProfileFolders = steamProfileFolders + profileFolders;
 
     ui->comboBox_3->clear();
+    this->button(QWizard::NextButton)->setEnabled(true); // 允许点击下一步
     if (allProfileFolders.isEmpty()) {
         qDebug() << "没有找到任何配置文件！";
         QMessageBox::critical(this, "错误", "没有找到任何游戏配置文件夹");
 
         // 没有找到配置文件就禁止点击下一步
         this->button(QWizard::NextButton)->setEnabled(false);
-
         return;
     }
 
@@ -439,7 +431,7 @@ bool ETS2KeyBinderWizard::initDirectInput() {
     HINSTANCE hInstance = GetModuleHandle(NULL);
     if (FAILED(DirectInput8Create(hInstance, DIRECTINPUT_VERSION, IID_IDirectInput8, (void**)&pDirectInput, NULL))) {
         qDebug() << "DirectInput 初始化失败！";
-        QMessageBox::critical(nullptr, "错误", "初始化DirectInput: 初始化失败！");
+        QMessageBox::critical(nullptr, "错误", "初始化DirectInput： 初始化失败！");
         return false;
     }
 
@@ -468,20 +460,20 @@ bool ETS2KeyBinderWizard::openDiDevice(int deviceIndex, HWND hWnd) {
     // 创建设备实例
     if (FAILED(pDirectInput->CreateDevice(diDeviceList[deviceIndex].guidInstance, &pDevice, NULL))) {
         qDebug() << "设备创建失败！";
-        QMessageBox::critical(this, "错误", "初始化设备: 设备创建失败！");
+        QMessageBox::warning(this, "警告", "初始化设备： 设备创建失败！");
         return false;
     }
 
     if (FAILED(pDevice->SetDataFormat(&c_dfDIJoystick2))) {
         qDebug() << "设置数据格式失败！";
-        QMessageBox::critical(this, "错误", "初始化设备: 设置数据格式失败！");
+        QMessageBox::warning(this, "警告", "初始化设备： 设置数据格式失败！");
         return false;
     }
 
     // 设置非独占模式(只有在施加力反馈时需要设置独占模式)
     if (FAILED(pDevice->SetCooperativeLevel(GetForegroundWindow(), DISCL_BACKGROUND | DISCL_NONEXCLUSIVE))) {
         qDebug() << "设置非独占模式失败！";
-        QMessageBox::critical(this, "错误", "初始化设备: 设置非独占模式失败！");
+        QMessageBox::warning(this, "警告", "初始化设备： 设置非独占模式失败！");
         return false;
     }
 
@@ -489,11 +481,11 @@ bool ETS2KeyBinderWizard::openDiDevice(int deviceIndex, HWND hWnd) {
     capabilities.dwSize = sizeof(DIDEVCAPS);
     if (FAILED(pDevice->GetCapabilities(&capabilities))) {
         qDebug() << "获取设备能力失败！";
-        QMessageBox::critical(this, "错误", "初始化设备: 获取设备能力失败！");
+        QMessageBox::warning(this, "警告", "初始化设备： 获取设备能力失败！");
         return false;
     }
     // 获取按钮数量
-    qDebug() << "按钮数量:" << capabilities.dwButtons;
+    qDebug() << "按钮数量：" << capabilities.dwButtons;
 
     return true;
 }
@@ -504,7 +496,7 @@ void ETS2KeyBinderWizard::scanDevice() {
     }
 
     if (FAILED(pDirectInput->EnumDevices(DI8DEVCLASS_GAMECTRL, EnumDevicesCallback, NULL, DIEDFL_ATTACHEDONLY))) {
-        QMessageBox::critical(nullptr, "错误", "扫描设备列表失败！");
+        QMessageBox::warning(nullptr, "警告", "扫描硬件设备列表失败！");
         return;
     }
 }
@@ -554,13 +546,18 @@ bool ETS2KeyBinderWizard::generateMappingFile(ActionEffect hblight, ActionEffect
 
 bool ETS2KeyBinderWizard::checkHardwareDeviceAndMsgBox() {
     if (deviceName.empty() || isDeviceReady == false) {
-        QMessageBox box(QMessageBox::Critical, "错误",
+        QMessageBox box(QMessageBox::Warning, "设备连接异常",
                         "请返回第3步，将设备连接到电脑，\n在“硬件控制设备”下拉框选择设备\n" + MEG_BOX_LINE + "\n或者进行手动绑定？");
         box.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
         box.setDefaultButton(QMessageBox::Ok);
         box.exec();
         if (box.clickedButton() == box.button(QMessageBox::Ok)) {
             on_pushButton_16_clicked();
+        } else {
+            // 返回第三步(不使用setCurrentId()跳转)
+            this->restart();
+            this->next();
+            this->next();
         }
         return false;
     }
@@ -618,14 +615,18 @@ void ETS2KeyBinderWizard::multiKeyBind(std::map<BindingType, ActionEffect> actio
     if (ret == QMessageBox::Ok) {
         backupProfile(); // 备份配置文件
         // 防止下标越界
-        if(ui->comboBox_2->currentIndex() >= 0 && ui->comboBox_2->currentIndex() < gameJoyPosNameList.size()){
+        if (ui->comboBox_2->currentIndex() >= 0 && ui->comboBox_2->currentIndex() < gameJoyPosNameList.size()) {
             QString gameJoyPosStr = gameJoyPosNameList[ui->comboBox_2->currentIndex()];
             for (auto item : actionEffectMap) {
                 QString ets2BtnStr = convertToETS2_String(gameJoyPosStr, item.second);
                 modifyControlsSii(selectedProfilePath, item.first, ets2BtnStr);
             }
-        }else{
+        } else {
             QMessageBox::critical(this, "错误", "还未选择游戏输入设备, 请返回第三步选择");
+            // 返回第三步(不使用setCurrentId()跳转)
+            this->restart();
+            this->next();
+            this->next();
         }
     }
 }
@@ -948,7 +949,7 @@ BigKey ETS2KeyBinderWizard::getKeyState() {
             isDeviceReady = true;
         }
     } else {
-        qDebug() << "获取设备状态信息失败!";
+        qDebug() << "获取设备状态信息失败！";
         qDebug() << "GetDeviceState failed with error:" << HRESULT_CODE(hr);
     }
 
@@ -962,7 +963,7 @@ void ETS2KeyBinderWizard::on_comboBox_3_activated(int index) {
         selectedProfilePath =
             profiles[ui->comboBox_4->currentIndex()] + "/" + profileFolders[index - steamProfileFolders.size()].first + "/controls.sii";
     } else {
-        qDebug() << "无效的配置文件索引:" << index;
+        qDebug() << "无效的配置文件索引：" << index;
     }
 }
 

--- a/ETS2_KeyBinder/ets2keybinderwizard.cpp
+++ b/ETS2_KeyBinder/ets2keybinderwizard.cpp
@@ -510,9 +510,9 @@ void ETS2KeyBinderWizard::scanDevice() {
 bool ETS2KeyBinderWizard::generateMappingFile(ActionEffect hblight, ActionEffect lighthorn) {
     // LightBinder.di_mappings_config 文件格式
     // [
-    //     {"dev_btn_name":"按键4", "dev_btn_type":"wheel_button", "dev_btn_value":"0", "keyboard_name":"K", "keyboard_value":37,
+    //     {"dev_btn_name":"按键4", "dev_btn_type":"wheel_button", "keyboard_name":"K", "keyboard_value":37,
     //     "remark":"远光灯", "rotateAxis":0, "btnTriggerType":5, "deviceName":"Generic   USB  Joystick  (00060079)"},
-    //     {"dev_btn_name":"按键4+按键7", "dev_btn_type":"wheel_button", "dev_btn_value":"0", "keyboard_name":"J", "keyboard_value":36,
+    //     {"dev_btn_name":"按键4+按键7", "dev_btn_type":"wheel_button", "keyboard_name":"J", "keyboard_value":36,
     //     "remark":"灯光喇叭", "rotateAxis":0, "btnTriggerType":0, "deviceName":"Generic   USB  Joystick  (00060079)"}
     // ]
 
@@ -538,12 +538,12 @@ bool ETS2KeyBinderWizard::generateMappingFile(ActionEffect hblight, ActionEffect
 
     QTextStream in(&lightBindingFile);
     in << "[\n{\"dev_btn_name\":\"" << hblightKeyStr;
-    in << "\", \"dev_btn_type\":\"wheel_button\", \"dev_btn_value\":\"0\", \"keyboard_name\":\"K\", \"keyboard_value\":37, "
+    in << "\", \"dev_btn_type\":\"wheel_button\", \"keyboard_name\":\"K\", \"keyboard_value\":37, "
           "\"remark\":\"远光灯\", \"rotateAxis\":0, \"btnTriggerType\":5, \"deviceName\":\"";
     in << joyName << "\"},\n";
 
     in << "{\"dev_btn_name\":\"" << lighthornKeyStr;
-    in << "\", \"dev_btn_type\":\"wheel_button\", \"dev_btn_value\":\"0\", \"keyboard_name\":\"J\", \"keyboard_value\":36,"
+    in << "\", \"dev_btn_type\":\"wheel_button\", \"keyboard_name\":\"J\", \"keyboard_value\":36,"
           "\"remark\":\"灯光喇叭\", \"rotateAxis\":0, \"btnTriggerType\":0, \"deviceName\":\"";
     in << joyName << "\"}\n]";
     return true;

--- a/ETS2_KeyBinder/ets2keybinderwizard.cpp
+++ b/ETS2_KeyBinder/ets2keybinderwizard.cpp
@@ -160,15 +160,18 @@ QStringList ETS2KeyBinderWizard::getDeviceNameGameList() {
         globalControlsFilePath = QDir::homePath() + "/Documents/American Truck Simulator/global_controls.sii";
     }
     QFile file(globalControlsFilePath);
+    QString errorMsg = "\n\n全局配置文件路径:\n" + globalControlsFilePath + "\n\n请返回第一步，确定已禁用Steam输入";
 
     if(!file.exists()){
-        QMessageBox::critical(this, "错误", "游戏全局配置文件不存在!\n配置文件路径:" + globalControlsFilePath);
+        QMessageBox::critical(this, "错误", "游戏全局配置文件不存在!" + errorMsg);
+        setCurrentId(0);
         return QStringList();
     }
 
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         qDebug() << "无法打开文件:" << file.fileName();
-        QMessageBox::critical(this, "错误", "打开游戏全局配置文件失败!\n配置文件路径:" + globalControlsFilePath);
+        QMessageBox::critical(this, "错误", "打开游戏全局配置文件失败!" + errorMsg);
+        setCurrentId(0);
         return QStringList();
     }
     QTextStream inGlobal(&file);

--- a/ETS2_KeyBinder/ets2keybinderwizard.cpp
+++ b/ETS2_KeyBinder/ets2keybinderwizard.cpp
@@ -24,7 +24,7 @@ using namespace std;
 
 ETS2KeyBinderWizard::ETS2KeyBinderWizard(QWidget* parent) : QWizard(parent), ui(new Ui::ETS2KeyBinderWizard) {
     ui->setupUi(this);
-    this->setWindowTitle("欧卡2/美卡-原生按键绑定向导 v1.0-beta.6");
+    this->setWindowTitle("欧卡2/美卡-原生按键绑定向导 v1.0-beta.7");
 #if defined(INDEPENDENT_MODE)
     this->setWindowTitle(this->windowTitle() + " " + QString(__DATE__) + " " + QString(__TIME__));
 #endif

--- a/ETS2_KeyBinder/ets2keybinderwizard.h
+++ b/ETS2_KeyBinder/ets2keybinderwizard.h
@@ -148,7 +148,7 @@ private:
     bool openDiDevice(int deviceIndex, HWND hWnd);
     void scanDevice();
     bool initDirectInput();
-    bool checkHardwareDeviceAndMsgBox();
+    bool checkHardwareDeviceAndMsgBox(BindingType bindingType = BindingType::lightpark);
 
     void updateUserProfile();
     bool backupProfile();
@@ -156,6 +156,8 @@ private:
     bool generateMappingFile(ActionEffect hblight, ActionEffect lighthorn);
 
     void modifyControlsSii(const QString& controlsFilePath, BindingType bindingType, const QString& ets2BtnStr);
+
+    void showManuallyBinder(BindingType bindingType);
 };
 
 #endif // ETS2KEYBINDERWIZARD_H

--- a/ETS2_KeyBinder/manuallybinder.cpp
+++ b/ETS2_KeyBinder/manuallybinder.cpp
@@ -1,35 +1,17 @@
 #include "manuallybinder.h"
 #include "ui_manuallybinder.h"
 #include <QMessageBox>
-#include <map>
 
 using namespace std;
 
 ManuallyBinder::ManuallyBinder(QWidget* parent) : QDialog(parent), ui(new Ui::ManuallyBinder) {
     ui->setupUi(this);
 
-    const map<BindingType, QString> bindingTypeComboxString = {
-        {BindingType::lightoff, "关闭灯光"},
-        {BindingType::lightpark, "示廓灯"},
-        {BindingType::lighton, "近光灯"},
-        {BindingType::lblinkerh, "左转向灯"},
-        {BindingType::rblinkerh, "右转向灯"},
-        {BindingType::hblight, "远光灯"},
-        {BindingType::lighthorn, "灯光喇叭"},
-        {BindingType::wipers0, "雨刷器关闭"},
-        {BindingType::wipers1, "雨刷器1档"},
-        {BindingType::wipers2, "雨刷器2档"},
-        {BindingType::wipers3, "雨刷器3档"},
-        {BindingType::gearsel1off, "档位开关1低档位"},
-        {BindingType::gearsel1on, "档位开关1高档位"},
-        {BindingType::gearsel2off, "档位开关2低档位"},
-        {BindingType::gearsel2on, "档位开关2高档位"},
-    };
     // 往下拉框添加绑定类型
     for (auto item : bindingTypeComboxString) {
         ui->comboBox->addItem(item.second);
     }
-    ui->comboBox->setCurrentIndex(1); // 默认选择第2个绑定类型
+    setBindingType(BindingType::lightpark); // 默认选择第2个绑定类型
 }
 
 ManuallyBinder::~ManuallyBinder() {
@@ -48,6 +30,14 @@ void ManuallyBinder::setKeyCount(size_t count) {
         ui->comboBox_2->addItem(QString::number(i + 1)); // 往下拉框添加按键
     }
     ui->comboBox_2->setCurrentIndex(0); // 重置下拉框选中项
+}
+
+void ManuallyBinder::setBindingType(BindingType bindingType) {
+    // 设置当前选中的绑定类型
+    if (bindingType < BindingType::lightoff || bindingType > BindingType::gearsel2on) {
+        bindingType = BindingType::lightpark; // 默认选择第2个绑定类型
+    }
+    ui->comboBox->setCurrentText(bindingTypeComboxString.at(bindingType)); // 设置当前选中的绑定类型
 }
 
 // 清空

--- a/ETS2_KeyBinder/manuallybinder.h
+++ b/ETS2_KeyBinder/manuallybinder.h
@@ -3,6 +3,7 @@
 
 #include "ets2keybinderwizard.h"
 #include <QDialog>
+#include <map>
 
 namespace Ui {
 class ManuallyBinder;
@@ -12,9 +13,28 @@ class ManuallyBinder : public QDialog {
     Q_OBJECT
 
 public:
+    const std::map<BindingType, QString> bindingTypeComboxString = {
+        {BindingType::lightoff, "关闭灯光"},
+        {BindingType::lightpark, "示廓灯"},
+        {BindingType::lighton, "近光灯"},
+        {BindingType::lblinkerh, "左转向灯"},
+        {BindingType::rblinkerh, "右转向灯"},
+        {BindingType::hblight, "远光灯"},
+        {BindingType::lighthorn, "灯光喇叭"},
+        {BindingType::wipers0, "雨刷器关闭"},
+        {BindingType::wipers1, "雨刷器1档"},
+        {BindingType::wipers2, "雨刷器2档"},
+        {BindingType::wipers3, "雨刷器3档"},
+        {BindingType::gearsel1off, "档位开关1低档位"},
+        {BindingType::gearsel1on, "档位开关1高档位"},
+        {BindingType::gearsel2off, "档位开关2低档位"},
+        {BindingType::gearsel2on, "档位开关2高档位"},
+    };
+
     explicit ManuallyBinder(QWidget* parent = nullptr);
     ~ManuallyBinder();
     void setKeyCount(size_t count);
+    void setBindingType(BindingType bindingType);
 
 signals:
     void keyBound(BindingType bindingType, ActionEffect actionEffect);


### PR DESCRIPTION
Hello啊，这个分支主要是更新`欧卡2/美卡 原生绑定向导`组件
- [update]移除多余的按钮值字段
- [update] 微调全局配置文件异常提示弹窗
- [update]调整为"非线性"向导流程 & 微调弹窗提示信息等
- [update]没有连接硬件设备时，点击单按键自动绑定，会联动手动绑定弹窗
- [fix] 修复手动绑定缺失 "?0" 字符段的BUG