### PR TITLE
修改`getDevBtnData`只返回变化的按键 & 修复 UI不响应

### DIFF
--- a/global.cpp
+++ b/global.cpp
@@ -421,7 +421,9 @@ QList<MappingRelation*> getInputState(bool enableLog, std::vector<MappingRelatio
                         }
                     }
                 }else{
-                    list.append(new MappingRelation(btnStr, WHEEL_BUTTON, 0, 0, "", TriggerTypeEnum::Normal, deviceName));
+                    MappingRelation *mapping =new MappingRelation(btnStr, WHEEL_BUTTON, 0, 0, "", TriggerTypeEnum::Normal, deviceName);
+                    mapping->setBtnBitValue(btnBitValue);  // 设置按键值
+                    list.append(mapping);
                 }
             }
             if(enableLog && getEnableBtnLog()){

--- a/global.cpp
+++ b/global.cpp
@@ -659,4 +659,16 @@ bool hasXboxMappingInMappingList(std::vector<MappingRelation*> mappingList){
 
     return false;
 }
-
+// BUTTONS_VALUE_TYPE 转换为字符串
+std::string ButtonsValueTypeToString(BUTTONS_VALUE_TYPE btnValue){
+    std::string btnValueStr = "";
+    for (size_t i = 0; i < MAX_BUTTONS; i++) {
+        if (btnValue.getBit(i)) {
+            btnValueStr += "按键" + std::to_string(i) + "+";
+        }
+    }
+    if (btnValueStr.size() > 0) {
+        btnValueStr.pop_back();  // 去掉最后的 "+"
+    }
+    return btnValueStr;
+}

--- a/global.h
+++ b/global.h
@@ -102,4 +102,7 @@ QString getAppDataDirStr();
 // 映射列表含有映射xbox的记录
 bool hasXboxMappingInMappingList(std::vector<MappingRelation*> mappingList);
 
+// BUTTONS_VALUE_TYPE 转换为字符串
+std::string ButtonsValueTypeToString(BUTTONS_VALUE_TYPE btnValue);
+
 #endif // GLOBAL_H


### PR DESCRIPTION
Hello啊，这个PR主要是修改`getDevBtnData`的按键相关的返回逻辑，只返回变化的按键；其次顺便修复了监听按钮时，UI不响应的问题。

### 输入状态处理和按钮值处理：

* **修复输入状态处理**：更新了“getInputState”，对“MappingRelation”对象设置按钮位值(“btnBitValue”)。
* **新函数**：添加了“ButtonsValueTypeToString”，将“BUTTONS_VALUE_TYPE”值转换`dev_btn_name`的字符串格式。[[1]](diffhunk://#diff-a88fe9ac7e60b596988f60fdebb6a10895f6e2fc6ff2dceb1e6f05837b98e486L662-R676) [[2]](diffhunk://#diff-c9848ba0b5db887a0fc07c2b9f605e3fba6eff9152037cb3d67775c0a5ff64e7R105-R107)

### 设备按钮数据检索：

* **按钮状态比较**：如果Sleep50ms的话，会导致有时获取的按键数据为空，因此修改为一直获取设备数据，同时了`getDevBtnData`的按键相关的返回逻辑，只返回变化的按键。

### 用户界面优化：

* **防止UI不响应**：删除了“on_pushButton_clicked”中的阻塞性“重新绘制”调用，并在“getDevBtnData”中添加了“QApplication:：processEvents”，以确保UI在设备输入监控期间保持响应。 [[1]](diffhunk://#diff-e12fae2282221bbdc52470acd3d3170f13683567557cca988671189c88ba7c45L665-L667) [[2]](diffhunk://#diff-e12fae2282221bbdc52470acd3d3170f13683567557cca988671189c88ba7c45L1174-R1213)