### PR TITLE
[update] 增加自动绑定的十字键方向映射 & 增加雨刷器4档（点动）绑定功能 & 修复按键输入为空时没有错误提示

### DIFF
--- a/BigKey.hpp
+++ b/BigKey.hpp
@@ -74,7 +74,7 @@ public:
 #define BIGKEY_ZERO BigKey::ZERO()
 
 private:
-#define BIGKEY_NUMBER 2  // 128位按键值，使用数组存储
+#define BIGKEY_NUMBER 3  // 128位按键值，使用数组存储
 #define BIGKEY_TYPE_INTERNAL uint64_t  // 内部存储类型
 
 #define MAX_BUTTONS (BIGKEY_NUMBER * (sizeof(BIGKEY_TYPE_INTERNAL) * 8))

--- a/ETS2_KeyBinder/ets2keybinderwizard.cpp
+++ b/ETS2_KeyBinder/ets2keybinderwizard.cpp
@@ -16,6 +16,13 @@
 const QString MEG_BOX_LINE = "------------------------";
 const QString MAPPING_FILE_NAME = "LightBinder";
 
+#define POV_MAX (4 * 4)
+std::map<int, size_t> povStandMap = {{0, 0}, {90, 1}, {180, 2}, {270, 3}}; // POV方向映射
+std::map<size_t, QString> povUiMap = {{0, "0度"}, {1, "90度"}, {2, "180度"}, {3, "270度"}};
+std::map<size_t, QString> povStringMap = {{0, "pov1_up"},  {1, "pov1_right"},  {2, "pov1_down"},  {3, "pov1_left"},
+                                          {4, "pov2_up"},  {5, "pov2_right"},  {6, "pov2_down"},  {7, "pov2_left"},
+                                          {8, "pov3_up"},  {9, "pov3_right"},  {10, "pov3_down"}, {11, "pov3_left"},
+                                          {12, "pov4_up"}, {13, "pov4_right"}, {14, "pov4_down"}, {15, "pov4_left"}};
 using namespace std;
 
 // 欧卡2 设置    “摇杆 Button0” 0基索引
@@ -24,7 +31,7 @@ using namespace std;
 
 ETS2KeyBinderWizard::ETS2KeyBinderWizard(QWidget* parent) : QWizard(parent), ui(new Ui::ETS2KeyBinderWizard) {
     ui->setupUi(this);
-    this->setWindowTitle("欧卡2/美卡-原生按键绑定向导 v1.0-beta.7");
+    this->setWindowTitle("欧卡2/美卡-原生按键绑定向导 v1.0-beta.8");
 #if defined(INDEPENDENT_MODE)
     this->setWindowTitle(this->windowTitle() + " " + QString(__DATE__) + " " + QString(__TIME__));
 #endif
@@ -130,9 +137,18 @@ ETS2KeyBinderWizard::ETS2KeyBinderWizard(QWidget* parent) : QWizard(parent), ui(
                     if (pDevice && showKeyState) {
                         BigKey keyState = getKeyState();     // 获取按键状态
                         showKeyState->setKeyState(keyState); // 更新按键状态窗口
+                        QString povState;
+                        for (size_t i = capabilities.dwButtons; i < capabilities.dwButtons + POV_MAX; i++) {
+                            size_t povIndex = i - capabilities.dwButtons;
+                            if (keyState.getBit(i)) {
+                                povState += povUiMap[povIndex % 4] + ",";
+                            }
+                        }
+                        povState.chop(1);                    // 去掉最后一个逗号
+                        showKeyState->setPovState(povState); // 更新十字键状态
                     }
                 });
-                timer->start(100); // 每100毫秒更新一次
+                timer->start(50); // 每50毫秒更新一次
             }
         }
     });
@@ -294,6 +310,7 @@ void ETS2KeyBinderWizard::modifyControlsSii(const QString& controlsFilePath, Bin
         {BindingType::wipers1, R"(mix wipers1 `.*?semantical\.wipers1\?0`)"},
         {BindingType::wipers2, R"(mix wipers2 `.*?semantical\.wipers2\?0`)"},
         {BindingType::wipers3, R"(mix wipers3 `.*?semantical\.wipers3\?0`)"},
+        {BindingType::wipers4, R"(mix wipers4 `.*?semantical\.wipers4\?0`)"},
         {BindingType::lightpark, R"(mix lightpark `.*?semantical\.lightpark\?0`)"},
         {BindingType::lighton, R"(mix lighton `.*?semantical\.lighton\?0`)"},
         {BindingType::hblight, R"(mix hblight `.*?semantical\.hblight\?0`)"},
@@ -306,11 +323,12 @@ void ETS2KeyBinderWizard::modifyControlsSii(const QString& controlsFilePath, Bin
     };
 
     map<BindingType, QString> bindingTypeString = {
-        {BindingType::lightoff, "lightoff"},     {BindingType::lighthorn, "lighthorn"},     {BindingType::wipers0, "wipers0"},
-        {BindingType::wipers1, "wipers1"},       {BindingType::wipers2, "wipers2"},         {BindingType::wipers3, "wipers3"},
-        {BindingType::lightpark, "lightpark"},   {BindingType::lighton, "lighton"},         {BindingType::hblight, "hblight"},
-        {BindingType::lblinkerh, "lblinkerh"},   {BindingType::rblinkerh, "rblinkerh"},     {BindingType::gearsel1off, "gearsel1off"},
-        {BindingType::gearsel1on, "gearsel1on"}, {BindingType::gearsel2off, "gearsel2off"}, {BindingType::gearsel2on, "gearsel2on"},
+        {BindingType::lightoff, "lightoff"},       {BindingType::lighthorn, "lighthorn"},   {BindingType::wipers0, "wipers0"},
+        {BindingType::wipers1, "wipers1"},         {BindingType::wipers2, "wipers2"},       {BindingType::wipers3, "wipers3"},
+        {BindingType::wipers4, "wipers4"},         {BindingType::lightpark, "lightpark"},   {BindingType::lighton, "lighton"},
+        {BindingType::hblight, "hblight"},         {BindingType::lblinkerh, "lblinkerh"},   {BindingType::rblinkerh, "rblinkerh"},
+        {BindingType::gearsel1off, "gearsel1off"}, {BindingType::gearsel1on, "gearsel1on"}, {BindingType::gearsel2off, "gearsel2off"},
+        {BindingType::gearsel2on, "gearsel2on"},
     };
 
     if (replaceRules.find(bindingType) == replaceRules.end()) {
@@ -357,9 +375,10 @@ void ETS2KeyBinderWizard::modifyControlsSii(const QString& controlsFilePath, Bin
 }
 
 // 将字符串转换为 ETS2 格式
-QString convertToETS2_String(const QString& gameJoyPosStr, const ActionEffect& actionEffect) {
+QString convertToETS2_String(const QString& gameJoyPosStr, const ActionEffect& actionEffect, size_t maxButtonCount = 128) {
     QString ets2BtnStr;
-    if (gameJoyPosStr.isEmpty() || actionEffect.empty()) {
+    QString gameJoyStr = gameJoyPosStr.trimmed();
+    if (gameJoyStr.isEmpty() || actionEffect.empty()) {
         return ets2BtnStr;
     }
     // 格式：joy3.b10?0 & !joy3.b11?0
@@ -367,7 +386,12 @@ QString convertToETS2_String(const QString& gameJoyPosStr, const ActionEffect& a
         if (item.second == false) {
             ets2BtnStr += "!";
         }
-        ets2BtnStr += gameJoyPosStr.trimmed() + ".b" + QString::number(item.first + 1) + "?0 & ";
+        if (item.first < maxButtonCount) {
+            ets2BtnStr += gameJoyStr + ".b" + QString::number(item.first + 1) + "?0 & ";
+        } else if (item.first < maxButtonCount + POV_MAX) { // POV
+            size_t povIndex = item.first - maxButtonCount;
+            ets2BtnStr += gameJoyStr + "." + povStringMap[povIndex] + "?0 & ";
+        }
     }
     ets2BtnStr.chop(3); // 去掉最后的 &
     qDebug() << "转换后的 ETS2 按键字符串：" << ets2BtnStr;
@@ -581,19 +605,17 @@ void ETS2KeyBinderWizard::oneKeyBind(BindingType bindingType, const QString& mes
         return; // 取消操作
     }
     keyState[0] = getKeyState(); // 获取按键状态
-    size_t keyPressCount = 0;
-    size_t keyPos = 0;
-    for (size_t i = 0; i < capabilities.dwButtons; i++) {
+    ActionEffect keyStateEffect;
+    for (size_t i = 0; i < capabilities.dwButtons + POV_MAX; i++) {
         if (keyState[0].getBit(i)) {
-            keyPressCount++;
-            keyPos = i;
+            keyStateEffect.insert_or_assign(i, true);
         }
     }
-    if (keyPressCount < 1) {
+    if (keyStateEffect.size() < 1) {
         QMessageBox::critical(this, "错误", "没有找到变化的按键！");
         return;
     }
-    if (keyPressCount > 1) {
+    if (keyStateEffect.size() > 1) {
         QMessageBox::critical(this, "错误", "找到多个按键按下！请重新操作！");
         return;
     }
@@ -603,7 +625,8 @@ void ETS2KeyBinderWizard::oneKeyBind(BindingType bindingType, const QString& mes
     if (ret == QMessageBox::Ok) {
         backupProfile(); // 备份配置文件
         int gameJoyPosIndex = ui->comboBox_2->currentIndex();
-        QString ets2BtnStr = gameJoyPosNameList[gameJoyPosIndex].trimmed() + ".b" + QString::number(keyPos + 1) + "?0";
+
+        QString ets2BtnStr = convertToETS2_String(gameJoyPosNameList[gameJoyPosIndex], keyStateEffect, capabilities.dwButtons);
         modifyControlsSii(selectedProfilePath, bindingType, ets2BtnStr);
     }
 }
@@ -618,7 +641,7 @@ void ETS2KeyBinderWizard::multiKeyBind(std::map<BindingType, ActionEffect> actio
         if (ui->comboBox_2->currentIndex() >= 0 && ui->comboBox_2->currentIndex() < gameJoyPosNameList.size()) {
             QString gameJoyPosStr = gameJoyPosNameList[ui->comboBox_2->currentIndex()];
             for (auto item : actionEffectMap) {
-                QString ets2BtnStr = convertToETS2_String(gameJoyPosStr, item.second);
+                QString ets2BtnStr = convertToETS2_String(gameJoyPosStr, item.second, capabilities.dwButtons);
                 modifyControlsSii(selectedProfilePath, item.first, ets2BtnStr);
             }
         } else {
@@ -693,7 +716,7 @@ void ETS2KeyBinderWizard::on_pushButton_clicked() {
         {BindingType::lightpark, ActionEffect()},
         {BindingType::lighton, ActionEffect()},
     };
-    for (size_t i = 0; i < capabilities.dwButtons; i++) {
+    for (size_t i = 0; i < capabilities.dwButtons + POV_MAX; i++) {
         if (keyStates[2].getBit(i) != keyStates[0].getBit(i) || keyStates[2].getBit(i) != keyStates[1].getBit(i)) {
             actionEffectMap[BindingType::lightoff].insert_or_assign(i, keyStates[0].getBit(i));
             actionEffectMap[BindingType::lightpark].insert_or_assign(i, keyStates[1].getBit(i));
@@ -722,7 +745,7 @@ void ETS2KeyBinderWizard::on_pushButton_2_clicked() {
         {BindingType::hblight, ActionEffect()},
         {BindingType::lighthorn, ActionEffect()},
     };
-    for (size_t i = 0; i < capabilities.dwButtons; i++) {
+    for (size_t i = 0; i < capabilities.dwButtons + POV_MAX; i++) {
         if (keyStates[1].getBit(i) != keyStates[0].getBit(i) || keyStates[2].getBit(i) != keyStates[0].getBit(i)) {
             actionEffectMap[BindingType::hblight].insert_or_assign(i, keyStates[1].getBit(i));
             actionEffectMap[BindingType::lighthorn].insert_or_assign(i, keyStates[2].getBit(i));
@@ -807,7 +830,7 @@ void ETS2KeyBinderWizard::on_pushButton_3_clicked() {
         {BindingType::lblinkerh, ActionEffect()},
         {BindingType::rblinkerh, ActionEffect()},
     };
-    for (size_t i = 0; i < capabilities.dwButtons; i++) {
+    for (size_t i = 0; i < capabilities.dwButtons + POV_MAX; i++) {
         if (keyStates[1].getBit(i) != keyStates[0].getBit(i)) {
             actionEffectMap[BindingType::lblinkerh].insert_or_assign(i, keyStates[1].getBit(i));
         }
@@ -822,13 +845,27 @@ void ETS2KeyBinderWizard::on_pushButton_3_clicked() {
 // 4、雨刮器
 void ETS2KeyBinderWizard::on_pushButton_4_clicked() {
     QString messageTitle = "雨刮器";
+    QString messageTitle1 = "3档雨刮器";
+    QString messageTitle2 = "4档雨刮器(3档+点动)";
     QStringList messages = {
         "请将拨杆拨到：\n" + MEG_BOX_LINE + "\n关闭位置",
         "请将拨杆拨到：\n" + MEG_BOX_LINE + "\n雨刮器1档",
         "请将拨杆拨到：\n" + MEG_BOX_LINE + "\n雨刮器2档",
         "请将拨杆拨到：\n" + MEG_BOX_LINE + "\n雨刮器3档",
     };
-    std::vector<BigKey> keyStates = getMultiKeyState(messageTitle, messages);
+    QMessageBox box(QMessageBox::Information, messageTitle, "您要绑定 " + messageTitle1 + " 还是 " + messageTitle2);
+    QPushButton* threeWipersButton = box.addButton("3档", QMessageBox::YesRole);
+    QPushButton* fourWipersButton = box.addButton("4档", QMessageBox::NoRole);
+    QPushButton* cancelButton = box.addButton("取消", QMessageBox::RejectRole);
+    box.exec();
+    if (box.clickedButton() == cancelButton) {
+        return; // 取消操作
+    } else if (box.clickedButton() == fourWipersButton) {
+        messages.append("请将拨杆拨到：\n" + MEG_BOX_LINE + "\n雨刮器4档（点动）");
+        messageTitle1 = messageTitle2;
+    }
+
+    std::vector<BigKey> keyStates = getMultiKeyState(messageTitle1, messages);
     if (keyStates.empty()) {
         return; // 取消操作
     }
@@ -840,13 +877,20 @@ void ETS2KeyBinderWizard::on_pushButton_4_clicked() {
     }
 
     std::map<BindingType, ActionEffect> actionEffectMap = {
-        {BindingType::wipers0, ActionEffect()},
-        {BindingType::wipers1, ActionEffect()},
-        {BindingType::wipers2, ActionEffect()},
-        {BindingType::wipers3, ActionEffect()},
+        {BindingType::wipers0, ActionEffect()}, {BindingType::wipers1, ActionEffect()}, {BindingType::wipers2, ActionEffect()},
+        {BindingType::wipers3, ActionEffect()}, {BindingType::wipers4, ActionEffect()},
     };
+    // 临时方法，待优化
+    if (box.clickedButton() == fourWipersButton) {
+        BigKey tempKeyState;
+        for (size_t i = 1; i < 4; i++) {
+            tempKeyState |= keyStates[0] ^ keyStates[i]; // 3档雨刮器
+        }
+        keyStates[4] = keyStates[4] & (~tempKeyState);
+        qDebug() << "keyStates[4]:" << keyStates[4];
+    }
 
-    for (size_t i = 0; i < capabilities.dwButtons; i++) {
+    for (size_t i = 0; i < capabilities.dwButtons + POV_MAX; i++) {
         if (keyStates[1].getBit(i) != keyStates[0].getBit(i)) {
             actionEffectMap[BindingType::wipers0].insert_or_assign(i, keyStates[0].getBit(i));
             actionEffectMap[BindingType::wipers1].insert_or_assign(i, keyStates[1].getBit(i));
@@ -859,6 +903,13 @@ void ETS2KeyBinderWizard::on_pushButton_4_clicked() {
             actionEffectMap[BindingType::wipers0].insert_or_assign(i, keyStates[0].getBit(i));
             actionEffectMap[BindingType::wipers3].insert_or_assign(i, keyStates[3].getBit(i));
         }
+        if (box.clickedButton() == fourWipersButton && keyStates[4].getBit(i) != keyStates[0].getBit(i)) {
+            actionEffectMap[BindingType::wipers0].insert_or_assign(i, keyStates[0].getBit(i));
+            actionEffectMap[BindingType::wipers4].insert_or_assign(i, keyStates[4].getBit(i));
+        }
+    }
+    if (box.clickedButton() == threeWipersButton) {
+        actionEffectMap.erase(BindingType::wipers4); // 删除4档雨刮
     }
 
     multiKeyBind(actionEffectMap); // 多按键绑定
@@ -880,7 +931,7 @@ void ETS2KeyBinderWizard::on_pushButton_18_clicked() {
         {BindingType::gearsel1off, ActionEffect()},
         {BindingType::gearsel1on, ActionEffect()},
     };
-    for (size_t i = 0; i < capabilities.dwButtons; i++) {
+    for (size_t i = 0; i < capabilities.dwButtons + POV_MAX; i++) {
         if (keyStates[1].getBit(i) != keyStates[0].getBit(i)) {
             actionEffectMap[BindingType::gearsel1on].insert_or_assign(i, keyStates[1].getBit(i));
             actionEffectMap[BindingType::gearsel1off].insert_or_assign(i, keyStates[0].getBit(i));
@@ -909,7 +960,7 @@ void ETS2KeyBinderWizard::on_pushButton_19_clicked() {
         {BindingType::gearsel2off, ActionEffect()},
         {BindingType::gearsel2on, ActionEffect()},
     };
-    for (size_t i = 0; i < capabilities.dwButtons; i++) {
+    for (size_t i = 0; i < capabilities.dwButtons + POV_MAX; i++) {
         if (keyStates[1].getBit(i) != keyStates[0].getBit(i)) {
             actionEffectMap[BindingType::gearsel2on].insert_or_assign(i, keyStates[1].getBit(i));
             actionEffectMap[BindingType::gearsel2off].insert_or_assign(i, keyStates[0].getBit(i));
@@ -920,6 +971,38 @@ void ETS2KeyBinderWizard::on_pushButton_19_clicked() {
         return;
     }
     multiKeyBind(actionEffectMap); // 多按键绑定
+}
+
+// 获取设备状态信息
+DIJOYSTATE2 ETS2KeyBinderWizard::getInputState() {
+    DIJOYSTATE2 js;
+    isDeviceReady = false;
+    if (pDevice == nullptr) {
+        return js; // 设备未打开
+    }
+
+    pDevice->Acquire();
+    HRESULT hr = pDevice->Poll();
+
+    // 检查连接状态
+    if (FAILED(hr)) {
+        hr = pDevice->Acquire();
+    }
+
+    // 检查是否成功获取
+    if (FAILED(hr)) {
+        qDebug() << "设备poll()失败，错误代码：" << HRESULT_CODE(hr);
+        return js;
+    }
+
+    // 获取按键状态
+    if (SUCCEEDED(pDevice->GetDeviceState(sizeof(DIJOYSTATE2), &js))) {
+        return js;
+    }
+
+    qDebug() << "获取设备状态信息失败!";
+    qDebug() << "GetDeviceState failed with error:" << HRESULT_CODE(hr);
+    return js;
 }
 
 BigKey ETS2KeyBinderWizard::getKeyState() {
@@ -946,15 +1029,30 @@ BigKey ETS2KeyBinderWizard::getKeyState() {
 
     if (SUCCEEDED(pDevice->GetDeviceState(sizeof(DIJOYSTATE2), &js))) {
         // 获取按键状态
-        for (size_t i = 0; i < capabilities.dwButtons; i++) {
+        for (size_t i = 0; i < capabilities.dwButtons + POV_MAX; i++) {
             keyState.setBit(i, (js.rgbButtons[i] & 0x80));
             isDeviceReady = true;
+        }
+        // 获取十字键状态
+        for (size_t i = 0; i < 4; i++) {
+
+            auto val = static_cast<int>(js.rgdwPOV[i]);
+
+            if (val > -1) {
+                // 格式化
+                for (;;) {
+                    if (val < 361) {
+                        break;
+                    }
+                    val /= 10;
+                }
+                keyState.setBit(povStandMap[val] + capabilities.dwButtons + i * 4, true);
+            }
         }
     } else {
         qDebug() << "获取设备状态信息失败！";
         qDebug() << "GetDeviceState failed with error:" << HRESULT_CODE(hr);
     }
-
     return keyState;
 }
 
@@ -1052,6 +1150,11 @@ void ETS2KeyBinderWizard::on_pushButton_12_clicked() {
 // 雨刷3档
 void ETS2KeyBinderWizard::on_pushButton_13_clicked() {
     oneKeyBind(BindingType::wipers3, "请将拨杆拨到：\n" + MEG_BOX_LINE + "\n雨刷3档");
+}
+
+// 雨刮4档（点动）
+void ETS2KeyBinderWizard::on_pushButton_24_clicked() {
+    oneKeyBind(BindingType::wipers4, "请将拨杆拨到：\n" + MEG_BOX_LINE + "\n雨刷4档（点动）");
 }
 
 // 远光灯

--- a/ETS2_KeyBinder/ets2keybinderwizard.h
+++ b/ETS2_KeyBinder/ets2keybinderwizard.h
@@ -27,6 +27,7 @@ enum class BindingType
     wipers1,     // 雨刷器1档
     wipers2,     // 雨刷器2档
     wipers3,     // 雨刷器3档
+    wipers4,     // 雨刷器点动
     gearsel1off, // 档位开关1关闭
     gearsel1on,  // 档位开关1打开
     gearsel2off, // 档位开关2关闭
@@ -115,6 +116,8 @@ private slots:
 
     void on_pushButton_23_clicked();
 
+    void on_pushButton_24_clicked();
+
 private:
     Ui::ETS2KeyBinderWizard* ui;
 
@@ -142,6 +145,7 @@ private:
     ShowKeyState* showKeyState = nullptr; // 显示按键状态窗口
     QTimer* timer = nullptr;              // 定时器
 
+    DIJOYSTATE2 getInputState();
     BigKey getKeyState();
 
     bool hasLastDevInCurrentDeviceList(std::string lastDeviceName);

--- a/ETS2_KeyBinder/ets2keybinderwizard.ui
+++ b/ETS2_KeyBinder/ets2keybinderwizard.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>426</width>
-    <height>421</height>
+    <height>431</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -56,7 +56,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="../resource.qrc">:/ETS2_KeyBinder/1_DisableSteamInput.jpg</pixmap>
+       <pixmap resource="resource.qrc">:/ETS2_KeyBinder/1_DisableSteamInput.jpg</pixmap>
       </property>
      </widget>
     </item>
@@ -180,7 +180,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="../resource.qrc">:/ETS2_KeyBinder/2_SelectInputDevice.jpg</pixmap>
+       <pixmap resource="resource.qrc">:/ETS2_KeyBinder/2_SelectInputDevice.jpg</pixmap>
       </property>
      </widget>
     </item>
@@ -567,9 +567,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>212</width>
-             <height>435</height>
+             <y>-226</y>
+             <width>374</width>
+             <height>480</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_8">
@@ -582,114 +582,24 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <item row="8" column="0">
-             <widget class="QLabel" name="label_18">
-              <property name="text">
-               <string>9、雨刷3档</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="label_13">
-              <property name="text">
-               <string>4、左转向灯</string>
-              </property>
-             </widget>
-            </item>
-            <item row="12" column="1">
-             <widget class="QPushButton" name="pushButton_21">
+            <item row="1" column="1">
+             <widget class="QPushButton" name="pushButton_6">
               <property name="text">
                <string>自动绑定</string>
               </property>
              </widget>
             </item>
-            <item row="7" column="0">
-             <widget class="QLabel" name="label_17">
-              <property name="text">
-               <string>8、雨刷2档</string>
-              </property>
-             </widget>
-            </item>
-            <item row="16" column="0" colspan="2">
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="12" column="0">
-             <widget class="QLabel" name="label_27">
-              <property name="text">
-               <string>13、档位开关1高档位</string>
-              </property>
-             </widget>
-            </item>
-            <item row="9" column="1">
+            <item row="10" column="1">
              <widget class="QPushButton" name="pushButton_14">
               <property name="text">
                <string>自动绑定</string>
               </property>
              </widget>
             </item>
-            <item row="9" column="0">
-             <widget class="QLabel" name="label_20">
+            <item row="14" column="0">
+             <widget class="QLabel" name="label_28">
               <property name="text">
-               <string>10、远光灯</string>
-              </property>
-             </widget>
-            </item>
-            <item row="11" column="0">
-             <widget class="QLabel" name="label_26">
-              <property name="text">
-               <string>12、档位开关1低档位</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_11">
-              <property name="text">
-               <string>2、示廓灯</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <widget class="QLabel" name="label_14">
-              <property name="text">
-               <string>5、右转向灯</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_19">
-              <property name="text">
-               <string>1、关闭灯光</string>
-              </property>
-             </widget>
-            </item>
-            <item row="7" column="1">
-             <widget class="QPushButton" name="pushButton_12">
-              <property name="text">
-               <string>自动绑定</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QPushButton" name="pushButton_7">
-              <property name="text">
-               <string>自动绑定</string>
-              </property>
-             </widget>
-            </item>
-            <item row="10" column="0">
-             <widget class="QLabel" name="label_21">
-              <property name="text">
-               <string>11、灯光喇叭</string>
+               <string>15、档位开关2低档位</string>
               </property>
              </widget>
             </item>
@@ -700,10 +610,10 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="0">
-             <widget class="QLabel" name="label_15">
+            <item row="6" column="1">
+             <widget class="QPushButton" name="pushButton_11">
               <property name="text">
-               <string>6、关闭雨刷</string>
+               <string>自动绑定</string>
               </property>
              </widget>
             </item>
@@ -714,6 +624,76 @@
               </property>
              </widget>
             </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_11">
+              <property name="text">
+               <string>2、示廓灯</string>
+              </property>
+             </widget>
+            </item>
+            <item row="13" column="1">
+             <widget class="QPushButton" name="pushButton_21">
+              <property name="text">
+               <string>自动绑定</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_15">
+              <property name="text">
+               <string>6、关闭雨刷</string>
+              </property>
+             </widget>
+            </item>
+            <item row="11" column="0">
+             <widget class="QLabel" name="label_21">
+              <property name="text">
+               <string>12、灯光喇叭</string>
+              </property>
+             </widget>
+            </item>
+            <item row="15" column="1">
+             <widget class="QPushButton" name="pushButton_23">
+              <property name="text">
+               <string>自动绑定</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_13">
+              <property name="text">
+               <string>4、左转向灯</string>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="0">
+             <widget class="QLabel" name="label_17">
+              <property name="text">
+               <string>8、雨刷2档</string>
+              </property>
+             </widget>
+            </item>
+            <item row="13" column="0">
+             <widget class="QLabel" name="label_27">
+              <property name="text">
+               <string>14、档位开关1高档位</string>
+              </property>
+             </widget>
+            </item>
+            <item row="14" column="1">
+             <widget class="QPushButton" name="pushButton_22">
+              <property name="text">
+               <string>自动绑定</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_14">
+              <property name="text">
+               <string>5、右转向灯</string>
+              </property>
+             </widget>
+            </item>
             <item row="4" column="1">
              <widget class="QPushButton" name="pushButton_9">
               <property name="text">
@@ -721,8 +701,15 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <widget class="QPushButton" name="pushButton_6">
+            <item row="12" column="0">
+             <widget class="QLabel" name="label_26">
+              <property name="text">
+               <string>13、档位开关1低档位</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QPushButton" name="pushButton_5">
               <property name="text">
                <string>自动绑定</string>
               </property>
@@ -742,24 +729,51 @@
               </property>
              </widget>
             </item>
+            <item row="17" column="0" colspan="2">
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
             <item row="11" column="1">
-             <widget class="QPushButton" name="pushButton_20">
+             <widget class="QPushButton" name="pushButton_15">
               <property name="text">
                <string>自动绑定</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QPushButton" name="pushButton_5">
+            <item row="2" column="1">
+             <widget class="QPushButton" name="pushButton_7">
               <property name="text">
                <string>自动绑定</string>
               </property>
              </widget>
             </item>
-            <item row="6" column="1">
-             <widget class="QPushButton" name="pushButton_11">
+            <item row="10" column="0">
+             <widget class="QLabel" name="label_20">
+              <property name="text">
+               <string>11、远光灯</string>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="1">
+             <widget class="QPushButton" name="pushButton_12">
               <property name="text">
                <string>自动绑定</string>
+              </property>
+             </widget>
+            </item>
+            <item row="15" column="0">
+             <widget class="QLabel" name="label_29">
+              <property name="text">
+               <string>16、档位开关2高档位</string>
               </property>
              </widget>
             </item>
@@ -770,38 +784,38 @@
               </property>
              </widget>
             </item>
-            <item row="10" column="1">
-             <widget class="QPushButton" name="pushButton_15">
+            <item row="8" column="0">
+             <widget class="QLabel" name="label_18">
+              <property name="text">
+               <string>9、雨刷3档</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_19">
+              <property name="text">
+               <string>1、关闭灯光</string>
+              </property>
+             </widget>
+            </item>
+            <item row="12" column="1">
+             <widget class="QPushButton" name="pushButton_20">
               <property name="text">
                <string>自动绑定</string>
               </property>
              </widget>
             </item>
-            <item row="13" column="1">
-             <widget class="QPushButton" name="pushButton_22">
+            <item row="9" column="0">
+             <widget class="QLabel" name="label_30">
+              <property name="text">
+               <string>10、雨刷4档（点动）</string>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="1">
+             <widget class="QPushButton" name="pushButton_24">
               <property name="text">
                <string>自动绑定</string>
-              </property>
-             </widget>
-            </item>
-            <item row="13" column="0">
-             <widget class="QLabel" name="label_28">
-              <property name="text">
-               <string>14、档位开关2低档位</string>
-              </property>
-             </widget>
-            </item>
-            <item row="14" column="1">
-             <widget class="QPushButton" name="pushButton_23">
-              <property name="text">
-               <string>自动绑定</string>
-              </property>
-             </widget>
-            </item>
-            <item row="14" column="0">
-             <widget class="QLabel" name="label_29">
-              <property name="text">
-               <string>15、档位开关2高档位</string>
               </property>
              </widget>
             </item>
@@ -838,7 +852,7 @@
   </widget>
  </widget>
  <resources>
-  <include location="../resource.qrc"/>
+  <include location="resource.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/ETS2_KeyBinder/manuallybinder.cpp
+++ b/ETS2_KeyBinder/manuallybinder.cpp
@@ -84,6 +84,10 @@ void ManuallyBinder::on_pushButton_clicked() {
 }
 
 void ManuallyBinder::on_pushButton_3_clicked() {
+    if (ui->lineEdit->text().isEmpty()) {
+        QMessageBox::critical(this, "错误", "请输入按键！");
+        return;
+    }
     QMessageBox box(QMessageBox::Information, "提示", "是否绑定？");
     box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     box.setDefaultButton(QMessageBox::Yes);

--- a/ETS2_KeyBinder/manuallybinder.h
+++ b/ETS2_KeyBinder/manuallybinder.h
@@ -25,6 +25,7 @@ public:
         {BindingType::wipers1, "雨刷器1档"},
         {BindingType::wipers2, "雨刷器2档"},
         {BindingType::wipers3, "雨刷器3档"},
+        {BindingType::wipers4, "雨刷器4档（点动）"},
         {BindingType::gearsel1off, "档位开关1低档位"},
         {BindingType::gearsel1on, "档位开关1高档位"},
         {BindingType::gearsel2off, "档位开关2低档位"},

--- a/ETS2_KeyBinder/showkeystate.cpp
+++ b/ETS2_KeyBinder/showkeystate.cpp
@@ -35,7 +35,7 @@ void ShowKeyState::initUi() {
         label->setAlignment(Qt::AlignCenter);
         // ui->gridLayout->addWidget(label);
         // 设置为2列布局
-        if (i  < keyCount / 2) {
+        if (i < keyCount / 2) {
             ui->gridLayout->addWidget(label, i, 0); // 第一列
         } else {
             ui->gridLayout->addWidget(label, i - keyCount / 2, 1); // 第二列
@@ -55,5 +55,13 @@ void ShowKeyState::setKeyState(BigKey& keyState) {
             }
         }
     }
-    
+}
+
+// 设置十字键状态
+void ShowKeyState::setPovState(QString povState) {
+    if (povState.isEmpty()) {
+        povState = "无"; // 默认值
+    }
+    povState = "十字键：" + povState; // 设置十字键状态
+    ui->labelPov->setText(povState);
 }

--- a/ETS2_KeyBinder/showkeystate.h
+++ b/ETS2_KeyBinder/showkeystate.h
@@ -4,7 +4,6 @@
 #include "BigKey.hpp"
 #include <QWidget>
 
-
 namespace Ui {
 class ShowKeyState;
 }
@@ -20,6 +19,7 @@ public:
 
 public slots:
     void setKeyState(BigKey& keyState); // 设置按键状态
+    void setPovState(QString povState); // 设置十字键状态
 
 private:
     Ui::ShowKeyState* ui;

--- a/ETS2_KeyBinder/showkeystate.ui
+++ b/ETS2_KeyBinder/showkeystate.ui
@@ -14,7 +14,17 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0">
+   <item row="3" column="0" colspan="2">
+    <layout class="QGridLayout" name="gridLayout"/>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="label">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -36,11 +46,24 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <layout class="QGridLayout" name="gridLayout"/>
+   <item row="5" column="0">
+    <widget class="QLabel" name="labelPov">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>十字键：</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignmentFlag::AlignCenter</set>
+     </property>
+    </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="Line" name="line">
+   <item row="4" column="0">
+    <widget class="Line" name="line_2">
      <property name="orientation">
       <enum>Qt::Orientation::Horizontal</enum>
      </property>


### PR DESCRIPTION
### 增加自动绑定的十字键方向映射
![image](https://github.com/user-attachments/assets/6f892df2-b5f9-4bcf-af24-659797fed0fd)

### 增加雨刷器4档（点动）绑定功能
![image](https://github.com/user-attachments/assets/aa5eae39-bb14-4021-80cd-6e75b22f4df4)
![image](https://github.com/user-attachments/assets/c9833c9b-2333-4c26-86af-0ef39e69b342)
![image](https://github.com/user-attachments/assets/82c52308-c409-4493-9565-79a201bb8a99)

### 修复按键输入为空时没有错误提示
![image](https://github.com/user-attachments/assets/24a77d74-e4f2-4ea2-b7ac-52ba10b26f4f)
