### PR TITLE
添加 `欧卡2/美卡` 同步映射功能（开发中...）

### DIFF
--- a/BtnTriggerTypeEnum.cpp
+++ b/BtnTriggerTypeEnum.cpp
@@ -7,4 +7,13 @@ std::map<TriggerTypeEnum, std::string> TRIGGER_TYPE_ENUM_MAP = {
     {Delay5s, "延迟5秒触发"},
     {Release, "按键松开时触发"},
     {PressAndRelease, "按下触发且松开也触发"},
+
+    {ETS2_SyncBlinkerLeft, "ETS2左转向灯同步"},
+    {ETS2_SyncBlinkerRight, "ETS2右转向灯同步"},
+    {ETS2_SyncLightsParking, "ETS2示廓灯同步"},
+    {ETS2_SyncLightsBeamLow, "ETS2近光灯同步"},
+    {ETS2_SyncLightsBeamHigh, "ETS2远光灯同步"},
+    {ETS2_SyncParkBrake, "ETS2手刹同步"},
+    {ETS2_SyncElectricEnabled, "ETS2通电同步"},
+    {ETS2_SyncEngineEnabled, "ETS2点火同步"},
 };

--- a/BtnTriggerTypeEnum.h
+++ b/BtnTriggerTypeEnum.h
@@ -13,8 +13,20 @@ enum TriggerTypeEnum {
     Release = 4,// 按键松开时触发
     PressAndRelease = 5,// 按下触发并且松开时再次触发
 
+    ETS2_SyncBlinkerLeft,     // ETS2左转向灯同步
+    ETS2_SyncBlinkerRight,    // ETS2右转向灯同步
+    ETS2_SyncLightsParking,   // ETS2示廓灯同步
+    ETS2_SyncLightsBeamLow,   // ETS2近光灯同步
+    ETS2_SyncLightsBeamHigh,  // ETS2远光灯同步
+    ETS2_SyncParkBrake,       // ETS2手刹同步
+    ETS2_SyncElectricEnabled, // ETS2通电同步
+    ETS2_SyncEngineEnabled,   // ETS2点火同步
+
     End //结束标识, 用于遍历枚举
 };
+
+#define TRIGGER_TYPE_ENUM_ETS2_SYNC_START TriggerTypeEnum::ETS2_SyncBlinkerLeft // ETS2同步开始标识
+#define TRIGGER_TYPE_ENUM_ETS2_SYNC_END TriggerTypeEnum::ETS2_SyncEngineEnabled // ETS2同步结束标识
 
 // 枚举对应信息map
 extern std::map<TriggerTypeEnum, std::string> TRIGGER_TYPE_ENUM_MAP;

--- a/global.h
+++ b/global.h
@@ -1,6 +1,7 @@
 #ifndef GLOBAL_H
 #define GLOBAL_H
 
+#include <QString>
 #include <QList>
 #include <dinput.h>
 #include <mapping_relation.h>
@@ -17,6 +18,7 @@ extern QWidget* g_mainWindow;
 
 // 全局映射是否开启
 extern bool isRuning;
+extern std::map<QString, BUTTONS_VALUE_TYPE> g_btnBitValueMap; // 全局按键值
 
 // 是否暂停全局映射
 extern bool isPause;
@@ -101,5 +103,8 @@ QString getAppDataDirStr();
 
 // 映射列表含有映射xbox的记录
 bool hasXboxMappingInMappingList(std::vector<MappingRelation*> mappingList);
+
+// BUTTONS_VALUE_TYPE 转换为字符串
+std::string ButtonsValueTypeToString(BUTTONS_VALUE_TYPE btnValue);
 
 #endif // GLOBAL_H

--- a/simulate_task.h
+++ b/simulate_task.h
@@ -6,6 +6,7 @@
 #include<windows.h>
 #include <ViGEm/Client.h>
 #include<key_map.h>
+#include"scs-telemetry-common.hpp"
 
 #define MAX_STR 255
 #define MAX_BUF 2048
@@ -31,6 +32,7 @@ private:
     //hid_device *handle;// 当前设备的连接句柄
     std::vector<MappingRelation*> mappingList;// 已配置的按键映射列表
     std::map<std::string, short> handleMap;// 设备按键对应键盘扫描码map; key: 设备-按键名称, value: 键盘扫描码
+    std::vector<MappingRelation> syncETS2Map;// 设备按键对应键盘扫描码map(用于同步ETS2/ATS游戏的按键映射)
     static std::vector<MappingRelation> handleMultiBtnVector;// 当前在使用的 设备组合键映射列表
     static std::vector<MappingRelation> handleMultiBtnVectorUnsort;// 未排序的 设备组合键映射列表
     static std::vector<MappingRelation> handleMultiBtnVectorSorted;// 已排序的 设备组合键映射列表(根据组合键的子键数量倒序)
@@ -69,6 +71,8 @@ signals:
     void pauseClickSignal();
 
 protected:
+    void handleETS2SyncMap(std::map<QString, BUTTONS_VALUE_TYPE>, scsTelemetryMap_t* pScsTelemtry);
+
     QList<MappingRelation*> handleResult(QList<MappingRelation*> res);
 
     bool isAxisRotate(std::string btnName);


### PR DESCRIPTION
Hello啊， ~~书接上回分支[Use_SCS_SDK](https://github.com/m-RNA/KeyMappingsTool/tree/Use_SCS_SDK)，~~ 这个分支主要是解决`原生按键绑定`不能覆盖所有的开关类型的同步，如远光灯，手刹、通电、点火等的问题；基于`SCS-SDK`插件中读取的遥测数据实现，目前还在开发中...

此外，浏览历史提交，这个PR似乎引入了 e213cfc46ea693d23fc65d4d211b4d8152d467c9 修复的BUG：全局映射启动后不生效全局映射线程被阻塞，但这边似乎没有出现（还是我的理解不对？

![image](https://github.com/user-attachments/assets/b0d3b59f-d046-4c06-9f05-f3acb0265986)
