### PR TITLE
[update]SCS_KeyBinder_v1.0-beta.9

### DIFF
--- a/ETS2_KeyBinder/ets2keybinderwizard.h
+++ b/ETS2_KeyBinder/ets2keybinderwizard.h
@@ -8,6 +8,7 @@
 #include "global.h"
 #include "showkeystate.h"
 #include <QDir>
+#include <QStandardPaths>
 #include <QWizard>
 #include <dinput.h>
 #include <string.h>
@@ -35,6 +36,9 @@ enum class BindingType
 };
 
 typedef std::map<int, bool> ActionEffect; // 受影响的按键位置和对应的新状态
+
+QString convertToETS2_String(const QString& gameJoyPosStr, const ActionEffect& actionEffect, size_t maxButtonCount = DINPUT_MAX_BUTTONS);
+QString convertToUiString(const QString& ets2BtnStr);
 
 namespace Ui {
 class ETS2KeyBinderWizard;
@@ -127,14 +131,16 @@ private:
     QStringList gameJoyPosNameList = {
         "joy ", "joy2", "joy3", "joy4", "joy5",
     };
-    QString steamProfiles[2] = {QDir::homePath() + "/Documents/Euro Truck Simulator 2/steam_profiles",
-                                QDir::homePath() + "/Documents/American Truck Simulator/steam_profiles"};
-    QString profiles[2] = {QDir::homePath() + "/Documents/Euro Truck Simulator 2/profiles",
-                           QDir::homePath() + "/Documents/American Truck Simulator/profiles"};
+    QString steamProfiles[2] = {QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/Euro Truck Simulator 2/steam_profiles",
+                                QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/American Truck Simulator/steam_profiles"};
+    QString profiles[2] = {QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/Euro Truck Simulator 2/profiles",
+                           QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/American Truck Simulator/profiles"};
     QString selectedProfilePath; // 选择的配置文件路径
 
     QList<QPair<QString, QDateTime>> steamProfileFolders;
     QList<QPair<QString, QDateTime>> profileFolders; // 所有配置文件列表
+
+    std::map<BindingType, QPushButton*> uiBtnMap;
 
     LPDIRECTINPUT8 pDirectInput = NULL;
     LPDIRECTINPUTDEVICE8 pDevice = NULL;

--- a/ETS2_KeyBinder/ets2keybinderwizard.ui
+++ b/ETS2_KeyBinder/ets2keybinderwizard.ui
@@ -217,7 +217,7 @@
     <string>第3步 选择游戏控制器</string>
    </property>
    <property name="subTitle">
-    <string>确保设备已经连接电脑，若列表中未出现，请重新进入第3步</string>
+    <string>确保设备已经连接电脑，若列表中未出现，请重新进入第3步。选好后在游戏中不要改动 ，若改动需要重新绑定</string>
    </property>
    <layout class="QGridLayout" name="gridLayout_4">
     <item row="0" column="0">
@@ -394,7 +394,7 @@
        <item row="1" column="0" colspan="2">
         <widget class="QCheckBox" name="checkBox_3">
          <property name="text">
-          <string>绑定单个灯光映射（暂仅支持控制器的单个按键绑定）</string>
+          <string>显示按键绑定、绑定单个映射（暂仅支持控制器的单个按键绑定）</string>
          </property>
         </widget>
        </item>
@@ -567,9 +567,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-226</y>
+             <y>0</y>
              <width>374</width>
-             <height>480</height>
+             <height>464</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_8">
@@ -710,6 +710,12 @@
             </item>
             <item row="0" column="1">
              <widget class="QPushButton" name="pushButton_5">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>自动绑定</string>
               </property>


### PR DESCRIPTION
Hello啊，这个Pr是对 SCS_KeyBinder 的常规更新（v1.0-beta.9）
1、使用 QStandardPaths 替换 QDir::homePath，确保文档路径的Win平台正确性 
2、添加单按钮映射界面写入的按键显示
3、更新说明文本: 第3步，增加绑定后游戏中不改动的提示；显示按键绑定、绑定单个映射
4、 加上 const 表示常量：povStandMap、povUiMap、povStringMap、replaceRules、bindingTypeString

![f13230db4d9fffb5e1ed6443d0cd52f4](https://github.com/user-attachments/assets/e8c7d674-de57-4c5f-b6a5-7846edcb2f4c)
